### PR TITLE
Remove the global lock that prevents duplicate file pickers

### DIFF
--- a/crates/file-picker/Cargo.toml
+++ b/crates/file-picker/Cargo.toml
@@ -54,6 +54,7 @@ objc2-ui-kit = { workspace = true, features = [
     "alloc",
     "block2",
     "UIApplication",
+    "UIPresentationController",
     "UIDocumentPickerViewController",
     "UIResponder",
     "UIView",

--- a/crates/file-picker/src/error.rs
+++ b/crates/file-picker/src/error.rs
@@ -15,7 +15,7 @@ pub enum Error {
     Io(std::io::Error),
     /// The provided file name isn't valid on the current platform.
     InvalidFileName,
-    /// Another dialog/picker is already open. Only one can be shown at a time.
+    /// The active native UI context is already presenting a file picker.
     AlreadyOpen,
     /// This platform is unsupported.
     Unsupported,

--- a/crates/file-picker/src/error.rs
+++ b/crates/file-picker/src/error.rs
@@ -15,7 +15,8 @@ pub enum Error {
     Io(std::io::Error),
     /// The provided file name isn't valid on the current platform.
     InvalidFileName,
-    /// The active native UI context is already presenting a file picker.
+    /// The native UI is already showing a file picker.
+    /// The user must cancel that one and try again.
     AlreadyOpen,
     /// This platform is unsupported.
     Unsupported,

--- a/crates/file-picker/src/lib.rs
+++ b/crates/file-picker/src/lib.rs
@@ -183,8 +183,7 @@ impl FileDialog {
     /// Shows a native open-file dialog.
     ///
     /// The callback is called with `Ok(None)` if the user cancels the dialog.
-    /// Returns [`Error::AlreadyOpen`] if the active native UI context is already
-    /// presenting a picker.
+    /// Returns [`Error::AlreadyOpen`] if a dialow is already being shown.
     pub fn pick_file<F>(self, on_completion: F) -> Result<()>
     where
         F: FnOnce(Result<Option<PickedFile>>) + Send + 'static,
@@ -232,8 +231,7 @@ impl FileDialog {
     /// With no explicit location set, defaults the start location to Pictures or
     /// Videos, which only the desktop dialog and document-picker fallbacks use.
     ///
-    /// Returns [`Error::AlreadyOpen`] if the active native UI context is already
-    /// presenting a picker.
+    /// Returns [`Error::AlreadyOpen`] if a dialow is already being shown.
     pub fn pick_media<F>(mut self, media_kind: MediaKind, on_completion: F) -> Result<()>
     where
         F: FnOnce(Result<Option<PickedFile>>) + Send + 'static,
@@ -251,8 +249,7 @@ impl FileDialog {
     ///
     /// You should first set a file name via [`FileDialog::set_file_name`],
     /// otherwise this will return [`Error::InvalidFileName`].
-    /// Returns [`Error::AlreadyOpen`] if the active native UI context is already
-    /// presenting a picker.
+    /// Returns [`Error::AlreadyOpen`] if a dialow is already being shown.
     pub fn save_data<D, F>(self, data: D, on_completion: F) -> Result<()>
     where
         D: AsRef<[u8]> + Send + 'static,

--- a/crates/file-picker/src/lib.rs
+++ b/crates/file-picker/src/lib.rs
@@ -41,7 +41,6 @@ mod error;
 mod sys;
 
 use std::{path::{Path, PathBuf}, sync::Arc};
-use picker_guard::lock_single_dialog;
 
 pub use error::{Error, Result};
 pub(crate) type DialogCallback = Box<dyn FnOnce(Result<Option<PickedFile>>) + Send + 'static>;
@@ -184,12 +183,13 @@ impl FileDialog {
     /// Shows a native open-file dialog.
     ///
     /// The callback is called with `Ok(None)` if the user cancels the dialog.
-    /// Returns [`Error::AlreadyOpen`] if a dialog is already open.
+    /// Returns [`Error::AlreadyOpen`] if the active native UI context is already
+    /// presenting a picker.
     pub fn pick_file<F>(self, on_completion: F) -> Result<()>
     where
         F: FnOnce(Result<Option<PickedFile>>) + Send + 'static,
     {
-        sys::pick_file(self.options, lock_single_dialog(Box::new(on_completion))?)
+        sys::pick_file(self.options, Box::new(on_completion))
     }
 
     /// Shows the platform's native image picker.
@@ -232,7 +232,8 @@ impl FileDialog {
     /// With no explicit location set, defaults the start location to Pictures or
     /// Videos, which only the desktop dialog and document-picker fallbacks use.
     ///
-    /// Returns [`Error::AlreadyOpen`] if a dialog is already open.
+    /// Returns [`Error::AlreadyOpen`] if the active native UI context is already
+    /// presenting a picker.
     pub fn pick_media<F>(mut self, media_kind: MediaKind, on_completion: F) -> Result<()>
     where
         F: FnOnce(Result<Option<PickedFile>>) + Send + 'static,
@@ -243,20 +244,21 @@ impl FileDialog {
                 MediaKind::Video => StartLocation::Videos,
             });
         }
-        sys::pick_media(self.options, media_kind, lock_single_dialog(Box::new(on_completion))?)
+        sys::pick_media(self.options, media_kind, Box::new(on_completion))
     }
 
     /// Saves the given `data` bytes to a user-specific location via platform-native operations.
     ///
     /// You should first set a file name via [`FileDialog::set_file_name`],
     /// otherwise this will return [`Error::InvalidFileName`].
-    /// Returns [`Error::AlreadyOpen`] if a dialog is already open.
+    /// Returns [`Error::AlreadyOpen`] if the active native UI context is already
+    /// presenting a picker.
     pub fn save_data<D, F>(self, data: D, on_completion: F) -> Result<()>
     where
         D: AsRef<[u8]> + Send + 'static,
         F: FnOnce(Result<Option<PickedFile>>) + Send + 'static,
     {
-        sys::save_data(self.options, Box::new(data), lock_single_dialog(Box::new(on_completion))?)
+        sys::save_data(self.options, Box::new(data), Box::new(on_completion))
     }
 
     /// Saves a file to the user's Downloads location.
@@ -629,42 +631,4 @@ enum FileLocation {
         owned_temp: bool,
     },
     Uri(String),
-}
-
-mod picker_guard {
-    use std::sync::atomic::{AtomicBool, Ordering};
-
-    /// Whether a native dialog/picker is currently being shown
-    static DIALOG_OPEN: AtomicBool = AtomicBool::new(false);
-
-    /// A guard type that enforces our invariant that only one picker/dialog can be open at at time.
-    struct PickerGuard;
-    impl PickerGuard {
-        fn acquire() -> Option<Self> {
-            if DIALOG_OPEN.swap(true, Ordering::SeqCst) {
-                None
-            } else {
-                Some(Self)
-            }
-        }
-    }
-    impl Drop for PickerGuard {
-        fn drop(&mut self) {
-            DIALOG_OPEN.store(false, Ordering::SeqCst);
-        }
-    }
-
-    /// A convenience function for ensuring a single picker/dialog is open
-    /// for the duration of the given `on_completion` callback being invoked.
-    ///
-    /// Returns [`Error::AlreadyOpen`] if a picker dialog is already open.
-    pub(crate) fn lock_single_dialog(
-        on_completion: crate::DialogCallback,
-    ) -> crate::Result<crate::DialogCallback> {
-        let guard = PickerGuard::acquire().ok_or(crate::Error::AlreadyOpen)?;
-        Ok(Box::new(move |result| {
-            let _guard = guard;
-            on_completion(result);
-        }))
-    }
 }

--- a/crates/file-picker/src/sys/android/FilePickerFragment.java
+++ b/crates/file-picker/src/sys/android/FilePickerFragment.java
@@ -18,6 +18,7 @@ import android.database.Cursor;
 import android.media.MediaScannerConnection;
 import android.net.Uri;
 import android.os.Build;
+import android.os.Looper;
 import android.provider.DocumentsContract;
 import android.provider.OpenableColumns;
 import android.os.Environment;
@@ -28,6 +29,8 @@ import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class FilePickerFragment extends Fragment {
     private static final int REQUEST_CODE = 0x526f;
@@ -37,6 +40,7 @@ public class FilePickerFragment extends Fragment {
     private static final int MEDIA_KIND_VIDEO = 2;
     private static final int MEDIA_KIND_PHOTO_OR_VIDEO = 3;
     private static final int API_Q = 29;
+    private static final String FRAGMENT_TAG = "robius.file_picker.FilePickerFragment";
     private static final String ACTION_PICK_IMAGES = "android.provider.action.PICK_IMAGES";
     private static final String COLUMN_DISPLAY_NAME = "_display_name";
     private static final String COLUMN_MIME_TYPE = "mime_type";
@@ -97,7 +101,7 @@ public class FilePickerFragment extends Fragment {
         this.launched = false;
     }
 
-    public static void show(
+    public static boolean show(
             Activity activity,
             long callbackPtr,
             boolean save,
@@ -119,14 +123,10 @@ public class FilePickerFragment extends Fragment {
                 initialLocationDir,
                 MEDIA_KIND_NONE);
 
-        activity
-                .getFragmentManager()
-                .beginTransaction()
-                .add(fragment, "robius.file_picker.FilePickerFragment." + callbackPtr)
-                .commitAllowingStateLoss();
+        return showFragment(activity, fragment);
     }
 
-    public static void saveData(
+    public static boolean saveData(
             Activity activity,
             long callbackPtr,
             String fileName,
@@ -147,14 +147,10 @@ public class FilePickerFragment extends Fragment {
                 initialLocationDir,
                 MEDIA_KIND_NONE);
 
-        activity
-                .getFragmentManager()
-                .beginTransaction()
-                .add(fragment, "robius.file_picker.FilePickerFragment." + callbackPtr)
-                .commitAllowingStateLoss();
+        return showFragment(activity, fragment);
     }
 
-    public static void pickMedia(
+    public static boolean pickMedia(
             Activity activity,
             long callbackPtr,
             int mediaKind,
@@ -171,22 +167,17 @@ public class FilePickerFragment extends Fragment {
                 null,
                 mediaKind);
 
-        activity
-                .getFragmentManager()
-                .beginTransaction()
-                .add(fragment, "robius.file_picker.FilePickerFragment." + callbackPtr)
-                .commitAllowingStateLoss();
+        return showFragment(activity, fragment);
     }
 
-    public static void saveToDownloads(
+    public static boolean saveToDownloads(
             Activity activity,
             long callbackPtr,
             String fileName,
             String mimeType,
             String sourcePath) {
         if (!canWriteDownloadsDirectly(activity)) {
-            show(activity, callbackPtr, true, null, fileName, sourcePath, mimeType, null, null);
-            return;
+            return show(activity, callbackPtr, true, null, fileName, sourcePath, mimeType, null, null);
         }
 
         new Thread(() -> {
@@ -204,6 +195,46 @@ public class FilePickerFragment extends Fragment {
 
             rustCallback(callbackPtr, resultCode, uri, null, null, -1);
         }, "robius-file-picker-save-to-downloads").start();
+        return true;
+    }
+
+    private static boolean showFragment(Activity activity, FilePickerFragment fragment) {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            return showFragmentOnUiThread(activity, fragment);
+        }
+
+        AtomicBoolean result = new AtomicBoolean(false);
+        CountDownLatch latch = new CountDownLatch(1);
+        activity.runOnUiThread(() -> {
+            try {
+                result.set(showFragmentOnUiThread(activity, fragment));
+            } finally {
+                latch.countDown();
+            }
+        });
+
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+        return result.get();
+    }
+
+    private static boolean showFragmentOnUiThread(Activity activity, FilePickerFragment fragment) {
+        if (activity.isFinishing() || activity.isDestroyed()) {
+            return false;
+        }
+        if (activity.getFragmentManager().findFragmentByTag(FRAGMENT_TAG) != null) {
+            return false;
+        }
+        activity
+                .getFragmentManager()
+                .beginTransaction()
+                .add(fragment, FRAGMENT_TAG)
+                .commitNowAllowingStateLoss();
+        return true;
     }
 
     @Override
@@ -259,10 +290,12 @@ public class FilePickerFragment extends Fragment {
 
         if (save) {
             // Writing the file might be slow, so don't do it on the main UI thread.
+            final Activity callbackActivity = activity;
             new Thread(
                 () -> {
                     boolean ok = copySourceToUri(resolver, dataUri);
-                    finish(ok ? okCode : RESULT_ERROR, ok ? uriString : null);
+                    callbackActivity.runOnUiThread(
+                            () -> finish(ok ? okCode : RESULT_ERROR, ok ? uriString : null));
                 },
                 "robius-file-picker-save"
             ).start();
@@ -400,7 +433,7 @@ public class FilePickerFragment extends Fragment {
     public void onDestroy() {
         super.onDestroy();
         // If the fragment is destroyed before a result was delivered,
-        // deliver a cancelation result to the native callback, which ensures
+        // deliver a cancellation result to the native callback, which ensures
         // that is always runs exactly once.
         long callback = claimCallback();
         if (callback != 0) {

--- a/crates/file-picker/src/sys/android/FilePickerFragment.java
+++ b/crates/file-picker/src/sys/android/FilePickerFragment.java
@@ -9,6 +9,7 @@ package robius.file_picker;
 import android.Manifest;
 import android.app.Activity;
 import android.app.Fragment;
+import android.app.FragmentTransaction;
 import android.content.ActivityNotFoundException;
 import android.content.ContentResolver;
 import android.content.ContentValues;
@@ -29,6 +30,7 @@ import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -226,12 +228,31 @@ public class FilePickerFragment extends Fragment {
         if (activity.isFinishing() || activity.isDestroyed()) {
             return false;
         }
-        if (activity.getFragmentManager().findFragmentByTag(FRAGMENT_TAG) != null) {
-            return false;
+
+        FragmentTransaction transaction = null;
+        List<Fragment> fragments = activity.getFragmentManager().getFragments();
+        if (fragments != null) {
+            for (Fragment existing : fragments) {
+                if (!(existing instanceof FilePickerFragment)) {
+                    continue;
+                }
+
+                FilePickerFragment picker = (FilePickerFragment) existing;
+                if (picker.hasCallback()) {
+                    return false;
+                }
+
+                if (transaction == null) {
+                    transaction = activity.getFragmentManager().beginTransaction();
+                }
+                transaction.remove(picker);
+            }
         }
-        activity
-                .getFragmentManager()
-                .beginTransaction()
+
+        if (transaction == null) {
+            transaction = activity.getFragmentManager().beginTransaction();
+        }
+        transaction
                 .add(fragment, FRAGMENT_TAG)
                 .commitNowAllowingStateLoss();
         return true;
@@ -445,6 +466,10 @@ public class FilePickerFragment extends Fragment {
         long callback = callbackPtr;
         callbackPtr = 0;
         return callback;
+    }
+
+    private synchronized boolean hasCallback() {
+        return callbackPtr != 0;
     }
 
     private void finish(int resultCode, String uri) {

--- a/crates/file-picker/src/sys/android/FilePickerFragment.java
+++ b/crates/file-picker/src/sys/android/FilePickerFragment.java
@@ -316,16 +316,15 @@ public class FilePickerFragment extends Fragment {
         final String uriString = dataUri.toString();
 
         if (save) {
-            // The user has chosen a destination, so the save operation now owns
-            // the callback. Destroying this fragment while copying should not
-            // report cancellation.
+            // If the user picked a save destination already, don't cancel even if
+            // this fragment gets randomly destroyed for some reason.
             final long callback = claimCallback();
             if (callback == 0) {
                 removeSelf();
                 return;
             }
 
-            // Writing the file might be slow, so don't do it on the main UI thread.
+            // Writing the file might be slow; don't do it on the main UI thread, duh.
             final Activity callbackActivity = activity;
             new Thread(
                 () -> {
@@ -474,9 +473,8 @@ public class FilePickerFragment extends Fragment {
     @Override
     public void onDestroy() {
         super.onDestroy();
-        // If the fragment is destroyed before a result was delivered,
-        // deliver a cancellation result to the native callback, which ensures
-        // that it always runs exactly once.
+        // If the fragment gets destroyed, deliver a cancellation result
+        // to ensure the callback always runs exactly once.
         long callback = claimCallback();
         if (callback != 0) {
             rustCallback(callback, Activity.RESULT_CANCELED, null, null, null, -1);

--- a/crates/file-picker/src/sys/android/FilePickerFragment.java
+++ b/crates/file-picker/src/sys/android/FilePickerFragment.java
@@ -206,20 +206,26 @@ public class FilePickerFragment extends Fragment {
         }
 
         AtomicBoolean result = new AtomicBoolean(false);
-        CountDownLatch latch = new CountDownLatch(1);
+        CountDownLatch uiThreadFinished = new CountDownLatch(1);
         activity.runOnUiThread(() -> {
             try {
                 result.set(showFragmentOnUiThread(activity, fragment));
             } finally {
-                latch.countDown();
+                uiThreadFinished.countDown();
             }
         });
 
-        try {
-            latch.await();
-        } catch (InterruptedException e) {
+        boolean interrupted = false;
+        while (true) {
+            try {
+                uiThreadFinished.await();
+                break;
+            } catch (InterruptedException e) {
+                interrupted = true;
+            }
+        }
+        if (interrupted) {
             Thread.currentThread().interrupt();
-            return false;
         }
         return result.get();
     }
@@ -310,13 +316,28 @@ public class FilePickerFragment extends Fragment {
         final String uriString = dataUri.toString();
 
         if (save) {
+            // The user has chosen a destination, so the save operation now owns
+            // the callback. Destroying this fragment while copying should not
+            // report cancellation.
+            final long callback = claimCallback();
+            if (callback == 0) {
+                removeSelf();
+                return;
+            }
+
             // Writing the file might be slow, so don't do it on the main UI thread.
             final Activity callbackActivity = activity;
             new Thread(
                 () -> {
                     boolean ok = copySourceToUri(resolver, dataUri);
-                    callbackActivity.runOnUiThread(
-                            () -> finish(ok ? okCode : RESULT_ERROR, ok ? uriString : null));
+                    rustCallback(
+                            callback,
+                            ok ? okCode : RESULT_ERROR,
+                            ok ? uriString : null,
+                            null,
+                            null,
+                            -1);
+                    callbackActivity.runOnUiThread(this::removeSelf);
                 },
                 "robius-file-picker-save"
             ).start();
@@ -455,7 +476,7 @@ public class FilePickerFragment extends Fragment {
         super.onDestroy();
         // If the fragment is destroyed before a result was delivered,
         // deliver a cancellation result to the native callback, which ensures
-        // that is always runs exactly once.
+        // that it always runs exactly once.
         long callback = claimCallback();
         if (callback != 0) {
             rustCallback(callback, Activity.RESULT_CANCELED, null, null, null, -1);
@@ -483,6 +504,10 @@ public class FilePickerFragment extends Fragment {
             rustCallback(callback, resultCode, uri, displayName, mimeType, size);
         }
 
+        removeSelf();
+    }
+
+    private void removeSelf() {
         if (getFragmentManager() != null) {
             getFragmentManager()
                     .beginTransaction()

--- a/crates/file-picker/src/sys/android/mod.rs
+++ b/crates/file-picker/src/sys/android/mod.rs
@@ -347,10 +347,10 @@ fn show_inner(
         .map(|loc| loc.as_ref())
         .unwrap_or(&null);
 
-    env.call_static_method(
+    let shown = env.call_static_method(
         fragment_class,
         "show",
-        "(Landroid/app/Activity;JZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;)V",
+        "(Landroid/app/Activity;JZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;)Z",
         &[
             JValueGen::Object(activity),
             JValueGen::Long(callback_ptr as i64),
@@ -362,9 +362,9 @@ fn show_inner(
             JValueGen::Object(mime_types),
             JValueGen::Object(initial_location),
         ],
-    )?;
+    )?.z()?;
 
-    Ok(())
+    shown.then_some(()).ok_or(Error::AlreadyOpen)
 }
 
 fn save_to_downloads_inner(
@@ -380,10 +380,10 @@ fn save_to_downloads_inner(
     let mime_type = env.new_string(mime_type)?;
     let source_path = env.new_string(source_path)?;
 
-    env.call_static_method(
+    let accepted = env.call_static_method(
         fragment_class,
         "saveToDownloads",
-        "(Landroid/app/Activity;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
+        "(Landroid/app/Activity;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z",
         &[
             JValueGen::Object(activity),
             JValueGen::Long(callback_ptr as i64),
@@ -391,9 +391,9 @@ fn save_to_downloads_inner(
             JValueGen::Object(mime_type.as_ref()),
             JValueGen::Object(source_path.as_ref()),
         ],
-    )?;
+    )?.z()?;
 
-    Ok(())
+    accepted.then_some(()).ok_or(Error::AlreadyOpen)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -436,10 +436,10 @@ fn save_data_inner(
         .map(|loc| loc.as_ref())
         .unwrap_or(&null);
 
-    env.call_static_method(
+    let shown = env.call_static_method(
         fragment_class,
         "saveData",
-        "(Landroid/app/Activity;JLjava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;[B)V",
+        "(Landroid/app/Activity;JLjava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;[B)Z",
         &[
             JValueGen::Object(activity),
             JValueGen::Long(callback_ptr as i64),
@@ -450,9 +450,9 @@ fn save_data_inner(
             JValueGen::Object(initial_location),
             JValueGen::Object(&data_array.into()),
         ],
-    )?;
+    )?.z()?;
 
-    Ok(())
+    shown.then_some(()).ok_or(Error::AlreadyOpen)
 }
 
 fn pick_media_inner(
@@ -470,19 +470,19 @@ fn pick_media_inner(
         .transpose()?;
     let title = title.as_ref().map(|title| title.as_ref()).unwrap_or(&null);
 
-    env.call_static_method(
+    let shown = env.call_static_method(
         fragment_class,
         "pickMedia",
-        "(Landroid/app/Activity;JILjava/lang/String;)V",
+        "(Landroid/app/Activity;JILjava/lang/String;)Z",
         &[
             JValueGen::Object(activity),
             JValueGen::Long(callback_ptr as i64),
             JValueGen::Int(android_media_kind(media_kind)),
             JValueGen::Object(title),
         ],
-    )?;
+    )?.z()?;
 
-    Ok(())
+    shown.then_some(()).ok_or(Error::AlreadyOpen)
 }
 
 fn android_media_kind(media_kind: MediaKind) -> i32 {

--- a/crates/file-picker/src/sys/ios/mod.rs
+++ b/crates/file-picker/src/sys/ios/mod.rs
@@ -12,7 +12,7 @@ use objc2::{
     define_class, extern_class, extern_conformance, extern_methods, extern_protocol, msg_send,
     rc::{Allocated, Retained},
     runtime::{AnyClass, ProtocolObject},
-    AnyThread, DeclaredClass, MainThreadMarker, MainThreadOnly,
+    AnyThread, ClassType, DeclaredClass, MainThreadMarker, MainThreadOnly,
 };
 use objc2_foundation::{
     NSArray, NSError, NSItemProvider, NSObject, NSObjectProtocol, NSString, NSURL,
@@ -22,8 +22,9 @@ use objc2_photos_ui::{
     PHPickerResult,
 };
 use objc2_ui_kit::{
-    UIApplication, UIDocumentPickerDelegate, UIDocumentPickerViewController, UIResponder,
-    UIViewController,
+    UIApplication, UIAdaptivePresentationControllerDelegate, UIDocumentPickerDelegate,
+    UIDocumentPickerViewController, UIPresentationController, UIResponder, UIViewController,
+    UIWindow,
 };
 use objc2_uniform_type_identifiers::{UTType, UTTypeImage, UTTypeItem, UTTypeMovie};
 
@@ -210,6 +211,14 @@ define_class!(
             self.finish(Ok(None));
         }
     }
+
+    unsafe impl UIAdaptivePresentationControllerDelegate for RobiusDocumentPickerDelegate {
+        #[unsafe(method(presentationControllerDidDismiss:))]
+        #[allow(non_snake_case)]
+        unsafe fn presentationControllerDidDismiss(&self, _: &UIPresentationController) {
+            self.finish(Ok(None));
+        }
+    }
 );
 
 define_class!(
@@ -228,6 +237,14 @@ define_class!(
             results: &NSArray<PHPickerResult>,
         ) {
             self.finish(picker, results);
+        }
+    }
+
+    unsafe impl UIAdaptivePresentationControllerDelegate for RobiusMediaPickerDelegate {
+        #[unsafe(method(presentationControllerDidDismiss:))]
+        #[allow(non_snake_case)]
+        unsafe fn presentationControllerDidDismiss(&self, _: &UIPresentationController) {
+            self.cancel();
         }
     }
 );
@@ -279,9 +296,16 @@ impl RobiusMediaPickerDelegate {
         self.ivars().pending.set(pending);
     }
 
-    fn finish(&self, picker: &PHPickerViewController, results: &NSArray<PHPickerResult>) {
-        dismiss_media_picker(picker);
+    fn cancel(&self) {
         let pending = self.ivars().pending.replace(ptr::null_mut());
+        if !pending.is_null() {
+            finish_media_picker(pending, Ok(None));
+        }
+    }
+
+    fn finish(&self, picker: &PHPickerViewController, results: &NSArray<PHPickerResult>) {
+        let pending = self.ivars().pending.replace(ptr::null_mut());
+        dismiss_media_picker(picker);
         if pending.is_null() { return; }
 
         let Some(result) = results.iter().next() else {
@@ -340,7 +364,7 @@ fn show_inner(
     kind: DialogKind,
     on_completion: DialogCallback,
 ) -> Result<()> {
-    let presenter = presenting_view_controller(mtm).ok_or(Error::Unknown)?;
+    let presenter = presenting_view_controller(mtm)?;
     let delegate = RobiusDocumentPickerDelegate::new(mtm);
 
     let (picker, temp_path) = match kind {
@@ -411,9 +435,12 @@ fn show_inner(
 
     // Safe upcast: `UIDocumentPickerViewController`'s superclass is `UIViewController`.
     let picker_view_controller: Retained<UIViewController> = picker.into_super();
+    let presentation_delegate = ProtocolObject::from_ref(&*delegate);
+    set_presentation_delegate(&picker_view_controller, presentation_delegate);
     unsafe {
         presenter.presentViewController_animated_completion(&picker_view_controller, true, None);
     }
+    set_presentation_delegate(&picker_view_controller, presentation_delegate);
 
     Ok(())
 }
@@ -434,7 +461,7 @@ fn show_media_inner(
         );
     }
 
-    let presenter = presenting_view_controller(mtm).ok_or(Error::Unknown)?;
+    let presenter = presenting_view_controller(mtm)?;
     let configuration = unsafe { PHPickerConfiguration::init(PHPickerConfiguration::alloc()) };
     let filter = media_filter(media_kind);
 
@@ -471,27 +498,71 @@ fn show_media_inner(
 
     // Safe upcast: `PHPickerViewController`'s superclass is `UIViewController`.
     let picker_view_controller: Retained<UIViewController> = picker.into_super();
+    let presentation_delegate = ProtocolObject::from_ref(&*delegate);
+    set_presentation_delegate(&picker_view_controller, presentation_delegate);
     unsafe {
         presenter.presentViewController_animated_completion(&picker_view_controller, true, None);
     }
+    set_presentation_delegate(&picker_view_controller, presentation_delegate);
 
     Ok(())
 }
 
-fn presenting_view_controller(mtm: MainThreadMarker) -> Option<Retained<UIViewController>> {
+fn set_presentation_delegate(
+    controller: &UIViewController,
+    delegate: &ProtocolObject<dyn UIAdaptivePresentationControllerDelegate>,
+) {
+    if let Some(presentation_controller) = unsafe { controller.presentationController() } {
+        unsafe {
+            presentation_controller.setDelegate(Some(delegate));
+        }
+    }
+}
+
+fn presenting_view_controller(mtm: MainThreadMarker) -> Result<Retained<UIViewController>> {
     let application = UIApplication::sharedApplication(mtm);
+    let window = active_window(&application).ok_or(Error::Unknown)?;
+    let root = window.rootViewController().ok_or(Error::Unknown)?;
+    top_presenting_view_controller(root)
+}
+
+fn active_window(application: &UIApplication) -> Option<Retained<UIWindow>> {
+    #[allow(deprecated)]
+    if let Some(window) = unsafe { application.keyWindow() } {
+        return Some(window);
+    }
 
     #[allow(deprecated)]
-    let window = unsafe { application.keyWindow() }.or_else(|| {
-        #[allow(deprecated)]
-        application.windows().iter().next()
-    })?;
+    let windows = application.windows();
+    windows
+        .iter()
+        .find(|window| window.isKeyWindow())
+        .or_else(|| windows.iter().next())
+}
 
-    let mut controller = window.rootViewController()?;
-    while let Some(presented) = unsafe { controller.presentedViewController() } {
+fn top_presenting_view_controller(
+    mut controller: Retained<UIViewController>,
+) -> Result<Retained<UIViewController>> {
+    loop {
+        if is_file_picker_controller(&controller) {
+            return Err(Error::AlreadyOpen);
+        }
+        let Some(presented) = (unsafe { controller.presentedViewController() }) else {
+            return Ok(controller);
+        };
         controller = presented;
     }
-    Some(controller)
+}
+
+fn is_file_picker_controller(controller: &UIViewController) -> bool {
+    if controller.isKindOfClass(UIDocumentPickerViewController::class()) {
+        return true;
+    }
+
+    let picker_class = CStr::from_bytes_with_nul(b"PHPickerViewController\0").unwrap();
+    AnyClass::get(picker_class)
+        .map(|class| controller.isKindOfClass(class))
+        .unwrap_or(false)
 }
 
 fn media_filter(media_kind: MediaKind) -> Retained<PHPickerFilter> {


### PR DESCRIPTION
we do it more natively now instead of a silly global lock, which was causing rare problems on iOS and Android if the system killed off the file/media picker that popped up.

* Android: uses a stable fragment tag to synchronously (not async) handle and check for existing fragments
* iOS: checks UIKit presentation stack for existing pickers and directly handles external (user or system) dismissal of existing pickers

Still need to test thoroughly on:
- [x] iOS
- [x] Android