### PR TITLE
Set lowest-possible MSRVs for each crate. Bump version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.4.2"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
  "event-listener",
  "event-listener-strategy",
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "async-signal"
-version = "0.2.14"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
 dependencies = [
  "async-io",
  "async-lock",
@@ -258,6 +258,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "combine"
 version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,7 +352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -447,12 +453,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,12 +478,12 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
+ "hashbrown",
  "serde",
  "serde_core",
 ]
@@ -627,6 +627,19 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
 
 [[package]]
 name = "objc2"
@@ -845,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.5.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit",
 ]
@@ -1100,7 +1113,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1230,7 +1243,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1289,32 +1302,32 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
  "toml_datetime",
  "toml_parser",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.0.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -1379,13 +1392,11 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "93d59ca99a559661b96bf898d8fce28ed87935fd2bea9f05983c1464dd6c71b1"
 dependencies = [
- "js-sys",
- "serde_core",
- "wasm-bindgen",
+ "serde",
 ]
 
 [[package]]
@@ -1508,7 +1519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
- "hashbrown 0.15.5",
+ "hashbrown",
  "indexmap",
  "semver",
 ]
@@ -1763,12 +1774,18 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"
@@ -1866,9 +1883,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.16.0"
+version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
+checksum = "b622b18155f7a93d1cd2dc8c01d2d6a44e08fb9ebb7b3f9e6ed101488bad6c91"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -1884,16 +1901,15 @@ dependencies = [
  "futures-core",
  "futures-lite",
  "hex",
- "libc",
+ "nix",
  "ordered-stream",
- "rustix",
  "serde",
  "serde_repr",
  "tracing",
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow",
+ "winnow 0.7.15",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -1901,9 +1917,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.16.0"
+version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6"
+checksum = "1cdb94821ca8a87ca9c298b5d1cbd80e2a8b67115d99f6e4551ac49e42b6a314"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1916,12 +1932,13 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "4.3.2"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
 dependencies = [
  "serde",
- "winnow",
+ "static_assertions",
+ "winnow 0.7.15",
  "zvariant",
 ]
 
@@ -1946,23 +1963,23 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zvariant"
-version = "5.12.0"
+version = "5.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
+checksum = "2be61892e4f2b1772727be11630a62664a1826b62efa43a6fe7449521cb8744c"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "winnow",
+ "winnow 0.7.15",
  "zvariant_derive",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.12.0"
+version = "5.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737"
+checksum = "da58575a1b2b20766513b1ec59d8e2e68db2745379f961f86650655e862d2006"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1973,13 +1990,14 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "3.4.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6"
+checksum = "e16edfee43e5d7b553b77872d99bc36afdda75c223ca7ad5e3fbecd82ca5fc34"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
+ "static_assertions",
  "syn",
- "winnow",
+ "winnow 0.7.15",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "android-build"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9994787facbc3375d2b510024117d11fa98087be537ac878033892193bbb33d2"
+checksum = "f9fc9904ad2ad097c3c1cfe2eacaaf0fc24710936fa9ed941cb310b7c6ed2ab7"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -352,7 +352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "robius-authentication"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "android-build",
  "block2",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "robius-common"
-version = "0.2.0"
+version = "0.3.0"
 
 [[package]]
 name = "robius-directories"
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "robius-file-picker"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "android-build",
  "block2",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "robius-location"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "android-build",
  "cfg-if",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "robius-share"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "android-build",
  "cfg-if",
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "robius-web-auth-session"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "block2",
  "cfg-if",
@@ -1113,7 +1113,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1243,7 +1243,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ objc2-uniform-type-identifiers = { version = "0.3.2", default-features = false, 
 
 
 ## Linux-specific dependencies used in multiple crates in the workspace.
-zbus = "5.12.0"
+zbus = ">=5.12.0, <5.13.0"
 zbus_polkit = "5.0.0"
 libc = "0.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ exclude = [
 
 ## Package details that are shared across multiple crates in the workspace.
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = [
     "Kevin Boos <kevinaboos@gmail.com>",
@@ -47,7 +47,7 @@ repository = "https://github.com/project-robius/robius"
 
 [workspace.dependencies]
 ## General dependencies (target-independent) used in multiple crates in the workspace.
-robius-common = { version = "0.2.0", path = "crates/common" }
+robius-common = { version = "0.3.0", path = "crates/common" }
 cfg-if = "1.0.0"
 log = "0.4"
 retry = "2.0.0"

--- a/crates/authentication/Cargo.toml
+++ b/crates/authentication/Cargo.toml
@@ -2,6 +2,7 @@
 name = "robius-authentication"
 version.workspace = true
 edition.workspace = true
+rust-version = "1.77.0"
 authors = [
     "Kevin Boos <kevinaboos@gmail.com>",
     "Klim Tsoutsman <klim@tsoutsman.com>",

--- a/crates/authentication/src/error.rs
+++ b/crates/authentication/src/error.rs
@@ -2,7 +2,8 @@
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// An error produced during authentication.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
+#[cfg_attr(not(target_os = "android"), derive(Clone))]
 pub enum Error {
     // TODO: Reexport jni::errors::Error
     // TODO: Remove target cfg

--- a/crates/authentication/src/error.rs
+++ b/crates/authentication/src/error.rs
@@ -2,13 +2,12 @@
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// An error produced during authentication.
-#[derive(Debug)]
-#[cfg_attr(not(target_os = "android"), derive(Clone))]
+#[derive(Debug, Clone)]
 pub enum Error {
     // TODO: Reexport jni::errors::Error
     // TODO: Remove target cfg
     #[cfg(target_os = "android")]
-    Java(jni::errors::Error),
+    Java(std::sync::Arc<jni::errors::Error>),
 
     // Common errors
     /// The user failed to provide valid credentials.
@@ -136,6 +135,6 @@ pub enum Error {
 #[cfg(target_os = "android")]
 impl From<jni::errors::Error> for Error {
     fn from(value: jni::errors::Error) -> Self {
-        Self::Java(value)
+        Self::Java(std::sync::Arc::new(value))
     }
 }

--- a/crates/authentication/src/lib.rs
+++ b/crates/authentication/src/lib.rs
@@ -36,8 +36,8 @@
 //!
 //! let callback = |auth_result| {
 //!     match auth_result {
-//!         Ok(_)  => log::info!("Authentication success!"),
-//!         Err(_) => log::error!(Authentication failed!"),
+//!         Ok(_)  => println!("Authentication success!"),
+//!         Err(_) => eprintln!("Authentication failed!"),
 //!     }
 //! };
 //!

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -2,6 +2,7 @@
 name = "robius-common"
 version.workspace = true
 edition.workspace = true
+rust-version = "1.64.0"
 authors = [
     "Kevin Boos <kevinaboos@gmail.com>",
     "Project Robius Maintainers",

--- a/crates/directories/Cargo.toml
+++ b/crates/directories/Cargo.toml
@@ -12,6 +12,7 @@ Supports Linux (XDG spec), Windows (Known Folders), macOS and iOS (Standard Dire
 This crate is a fork of the (now-archived) `directories` crate, with support for Android.
 """
 edition     = "2015"
+rust-version = "1.77.0"
 readme      = "README.md"
 license     = "MIT OR Apache-2.0"
 repository  = "https://github.com/project-robius/robius"

--- a/crates/directories/src/lib.rs
+++ b/crates/directories/src/lib.rs
@@ -60,7 +60,7 @@ use lin as sys;
 /// All examples on this page are computed with a user named _Alice_.
 ///
 /// ```
-/// use robius-directories::BaseDirs;
+/// use robius_directories::BaseDirs;
 /// if let Some(base_dirs) = BaseDirs::new() {
 ///     base_dirs.config_dir();
 ///     // Linux:   /home/alice/.config
@@ -92,7 +92,7 @@ pub struct BaseDirs {
 /// All examples on this page are computed with a user named _Alice_.
 ///
 /// ```
-/// use robius-directories::UserDirs;
+/// use robius_directories::UserDirs;
 /// if let Some(user_dirs) = UserDirs::new() {
 ///     user_dirs.audio_dir();
 ///     // Linux:   /home/alice/Music
@@ -127,7 +127,7 @@ pub struct UserDirs {
 /// and a `ProjectDirs` struct created with `ProjectDirs::from("com", "Foo Corp", "Bar App")`.
 ///
 /// ```
-/// use robius-directories::ProjectDirs;
+/// use robius_directories::ProjectDirs;
 /// if let Some(proj_dirs) = ProjectDirs::from("com", "Foo Corp",  "Bar App") {
 ///     proj_dirs.config_dir();
 ///     // Linux:   /home/alice/.config/barapp

--- a/crates/file-picker/Cargo.toml
+++ b/crates/file-picker/Cargo.toml
@@ -2,6 +2,7 @@
 name = "robius-file-picker"
 version.workspace = true
 edition.workspace = true
+rust-version = "1.88.0"
 authors = [
     "Kevin Boos <kevinaboos@gmail.com>",
     "Project Robius Maintainers",

--- a/crates/file-picker/src/lib.rs
+++ b/crates/file-picker/src/lib.rs
@@ -113,7 +113,7 @@ impl FileDialog {
     ///
     /// Passing an empty set clears all filters, including those previously added via `add_filter()`.
     ///
-    /// ```norun
+    /// ```no_run
     /// # use robius_file_picker::FileDialog;
     /// let dialog = FileDialog::new().set_filters([
     ///     ("Images", &["png", "jpg"]),

--- a/crates/file-picker/src/sys/ios/mod.rs
+++ b/crates/file-picker/src/sys/ios/mod.rs
@@ -805,7 +805,7 @@ fn resolve_regular_file(path: PathBuf) -> Result<PathBuf> {
                 continue;
             }
             let priority = file_type_priority(&p);
-            if best.as_ref().is_none_or(|(best_prio, _)| priority > *best_prio) {
+            if best.as_ref().map_or(true, |(best_prio, _)| priority > *best_prio) {
                 best = Some((priority, p));
             }
         }

--- a/crates/location/Cargo.toml
+++ b/crates/location/Cargo.toml
@@ -2,6 +2,7 @@
 name = "robius-location"
 version.workspace = true
 edition.workspace = true
+rust-version = "1.77.0"
 authors = [
     "Kevin Boos <kevinaboos@gmail.com>",
     "Klim Tsoutsman <klim@tsoutsman.com>",

--- a/crates/open/Cargo.toml
+++ b/crates/open/Cargo.toml
@@ -2,6 +2,7 @@
 name = "robius-open"
 version = "0.3.0"
 edition.workspace = true
+rust-version = "1.77.0"
 authors = [
     "Kevin Boos <kevinaboos@gmail.com>",
     "Klim Tsoutsman <klim@tsoutsman.com>",

--- a/crates/open/src/lib.rs
+++ b/crates/open/src/lib.rs
@@ -23,7 +23,7 @@
 //! use robius_open::Uri;
 //! Uri::new("http://www.google.com")
 //!    .open_with_completion(|success| {
-//!       log!("Opened URI? {success}");
+//!       println!("Opened URI? {success}");
 //!    })
 //!    .expect("failed to open URL");
 //! ```

--- a/crates/open/src/sys/ios.rs
+++ b/crates/open/src/sys/ios.rs
@@ -6,7 +6,6 @@ use objc2_foundation::{NSDictionary, NSString, NSURL};
 use objc2::runtime::Bool;
 use objc2_ui_kit::UIApplication;
 
-
 use crate::{Error, Result};
 
 pub(crate) struct Uri<'a, 'b> {
@@ -37,10 +36,9 @@ impl<'a, 'b> Uri<'a, 'b> {
         // iOS requires that we call openURL on the main thread.
         run_on_main(move |mtm| {
             let string = NSString::from_str(self.inner);
-            let url = unsafe { NSURL::URLWithString(&string) }
-                .ok_or(Error::MalformedUri)?;
+            let url = NSURL::URLWithString(&string).ok_or(Error::MalformedUri)?;
             let application = UIApplication::sharedApplication(mtm);
-    
+
             let block = RcBlock::new(move |success: Bool| {
                 #[cfg(feature = "log")]
                 log::trace!("Calling on_completion closure with success: {}", success.as_raw());

--- a/crates/web_auth_session/Cargo.toml
+++ b/crates/web_auth_session/Cargo.toml
@@ -2,6 +2,7 @@
 name = "robius-web-auth-session"
 version.workspace = true
 edition.workspace = true
+rust-version = "1.71.0"
 authors = [
     "Kevin Boos <kevinaboos@gmail.com>",
     "Project Robius Maintainers",

--- a/crates/web_auth_session/src/sys/ios.rs
+++ b/crates/web_auth_session/src/sys/ios.rs
@@ -41,7 +41,7 @@ define_class!(
             // Deprecated for multi-scene apps, fine for single-scene.
             // Swap for a connectedScenes lookup if your app uses scenes.
             #[allow(deprecated)]
-            let window: Option<Retained<UIWindow>> = unsafe { app.keyWindow() }
+            let window: Option<Retained<UIWindow>> = app.keyWindow()
                 .or_else(|| {
                     #[allow(deprecated)]
                     let windows = app.windows();
@@ -146,7 +146,7 @@ where
 
     run_on_main(move |mtm| -> Result<Handle> {
         let url_ns = NSString::from_str(&url);
-        let url_obj = unsafe { NSURL::URLWithString(&url_ns) }.ok_or(Error::MalformedUri)?;
+        let url_obj = NSURL::URLWithString(&url_ns).ok_or(Error::MalformedUri)?;
         let scheme_ns = NSString::from_str(&callback_scheme);
 
         let context_provider = PresentationContextProvider::new(mtm);
@@ -192,7 +192,7 @@ where
                 }
             } else if !callback_url.is_null() {
                 let url = unsafe { &*callback_url };
-                Ok(unsafe { url.absoluteString() }
+                Ok(url.absoluteString()
                     .map(|s| s.to_string())
                     .unwrap_or_default())
             } else {


### PR DESCRIPTION
Most are now at Rust 1.77, except for `robius-file-picker` which needs Rust 1.88 due to `rfd` deps

a few other minor fixes too