### PR TITLE
location: fix Android, make requests faster/more robust on all platforms

### DIFF
--- a/crates/location/Cargo.toml
+++ b/crates/location/Cargo.toml
@@ -8,7 +8,7 @@ authors = [
     "Klim Tsoutsman <klim@tsoutsman.com>",
     "Project Robius Maintainers",
 ]
-description = "Rust abstractions for multi-platform native authentication: biometrics, fingerprint, password, screen lock, TouchID, FaceID, Windows Hello, etc."
+description = "Rust abstractions for accessing native geo-location (e.g., GPS) across platforms."
 documentation = "https://docs.rs/robius-location"
 homepage.workspace = true
 keywords = ["robius", "location", "coordinate", "geo", "GPS"]

--- a/crates/location/README.md
+++ b/crates/location/README.md
@@ -4,9 +4,6 @@ A Rust library to access system-provided location/GPS data across multiple platf
 
 Currently supports iOS, macOS, Windows, and Android, with Linux support coming soon.
 
-**There is a known problem on Android** in which the request-permissions prompt displayed to the user may not always appear and the application may crash (but will then work permanently on the next run); see [issue #2](https://github.com/project-robius/robius/issues/2).
-
-
 ## Usage on iOS
 To use this crate on iOS, you must add the following to your app's `Info.plist`:
 ```xml

--- a/crates/location/build.rs
+++ b/crates/location/build.rs
@@ -1,49 +1,65 @@
-use std::{env, path::PathBuf};
+use std::{env, fs, path::PathBuf};
 
-const JAVA_FILE_RELATIVE_PATH: &str = "src/sys/android/LocationCallback.java";
+const JAVA_FILES_RELATIVE_PATHS: &[&str] = &[
+    "src/sys/android/LocationCallback.java",
+    "src/sys/android/LocationPermissionFragment.java",
+];
 
 fn main() {
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
 
     if target_os == "android" {
-        println!("cargo:rerun-if-changed={JAVA_FILE_RELATIVE_PATH}");
-
         let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-        let java_file =
-            PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join(JAVA_FILE_RELATIVE_PATH);
+        let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
 
         let android_jar_path =
             android_build::android_jar(None).expect("Failed to find android.jar");
 
-        // Compile the .java file into a .class file.
+        // Compile all `.java` files into `.class` files.
+        let mut java_build = android_build::JavaBuild::new();
+        java_build
+            .class_path(android_jar_path.clone())
+            .classes_out_dir(out_dir.clone());
+        for relative_path in JAVA_FILES_RELATIVE_PATHS {
+            println!("cargo:rerun-if-changed={relative_path}");
+            java_build.file(manifest_dir.join(relative_path));
+        }
         assert!(
-            android_build::JavaBuild::new()
-                .class_path(android_jar_path.clone())
-                .classes_out_dir(out_dir.clone())
-                .file(java_file)
+            java_build
                 .compile()
                 .expect("failed to acquire exit status for javac invocation")
                 .success(),
             "javac invocation failed"
         );
 
-        let class_file = out_dir
-            .join("robius")
-            .join("location")
-            .join("LocationCallback.class");
+        // Collect every generated `.class` file (there may be more than one per source file, e.g.
+        // synthetic classes) so they all land in the single `classes.dex`.
+        let classes_dir = out_dir.join("robius").join("location");
+        let class_files: Vec<PathBuf> = fs::read_dir(&classes_dir)
+            .expect("failed to read compiled classes directory")
+            .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+            .filter(|path| path.extension().is_some_and(|ext| ext == "class"))
+            .collect();
+        assert!(
+            !class_files.is_empty(),
+            "no compiled .class files found in {}",
+            classes_dir.display()
+        );
 
         let d8_jar_path = android_build::android_d8_jar(None).expect("Failed to find d8.jar");
 
+        let mut d8 = android_build::JavaRun::new();
+        d8.class_path(d8_jar_path)
+            .main_class("com.android.tools.r8.D8")
+            .arg("--classpath")
+            .arg(android_jar_path)
+            .arg("--output")
+            .arg(&out_dir);
+        for class_file in &class_files {
+            d8.arg(class_file);
+        }
         assert!(
-            android_build::JavaRun::new()
-                .class_path(d8_jar_path)
-                .main_class("com.android.tools.r8.D8")
-                .arg("--classpath")
-                .arg(android_jar_path)
-                .arg("--output")
-                .arg(&out_dir)
-                .arg(&class_file)
-                .run()
+            d8.run()
                 .expect("failed to acquire exit status for java d8.jar invocation")
                 .success(),
             "java d8.jar invocation failed"

--- a/crates/location/src/lib.rs
+++ b/crates/location/src/lib.rs
@@ -27,7 +27,7 @@ pub use crate::error::{Error, Result};
 ///
 /// **All location manager functions must be called from the main thread**.
 ///
-/// As soon as the handler is registered, it may receive updates immediatly,
+/// As soon as the handler is registered, it may receive updates immediately,
 /// even if `update_once` or `start_updates` are not called.
 /// When the manager is dropped, the handler is no longer guaranteed to receive updates.
 pub struct Manager {
@@ -49,12 +49,14 @@ impl Manager {
 
     /// Requests authorization to access location data.
     ///
-    /// This will return immediately and request authorization in the background.
+    /// iOS/Android: returns immediately; a request made before authorization is deferred until the
+    /// user responds, and a denial goes to [`Handler::error`]. Windows: blocks and returns the result.
     pub fn request_authorization(&self, access: Access, accuracy: Accuracy) -> Result<()> {
         self.inner.request_authorization(access, accuracy)
     }
 
-    /// Delivers a single update to the handler.
+    /// Requests the device's current location, delivered to the handler. May deliver a cached fix
+    /// immediately, then a fresher one once acquired.
     pub fn update_once(&self) -> Result<()> {
         self.inner.update_once()
     }

--- a/crates/location/src/sys/android/LocationCallback.java
+++ b/crates/location/src/sys/android/LocationCallback.java
@@ -2,10 +2,16 @@
 
 package robius.location;
 
+import android.location.Criteria;
 import android.location.Location;
 import android.location.LocationListener;
+import android.location.LocationManager;
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
 import java.util.function.Consumer;
 import java.util.List;
+import java.util.concurrent.Executor;
 
 /*
  * `Consumer<Location>` is implemented for `LocationManager.getCurrentLocation`.
@@ -13,20 +19,41 @@ import java.util.List;
  */
 
 public class LocationCallback implements Consumer<Location>, LocationListener {
-    private long handlerPtrHigh;
-    private long handlerPtrLow;
-    private boolean executing;
-    private boolean doNotExecute;
+    // If a cached fix is at least this recent, just use it instead of waiting for a new one.
+    private static final long FRESH_ENOUGH_MILLIS = 60_000L;
+    // How long to wait for a new fix before giving up and using the cached one.
+    private static final long GRACE_MILLIS = 4_000L;
+    // On API 26-29 requestSingleUpdate has no timeout of its own, so we add one.
+    private static final long CLASSIC_GIVE_UP_MILLIS = 10_000L;
+    // Just in case getCurrentLocation (API 30+) never calls us back.
+    private static final long CURRENT_BACKSTOP_MILLIS = 45_000L;
+
+    // Pointer to the Rust-side `Shared`. It's a thin pointer, so it fits in one `long`.
+    private long sharedPtr;
+    // volatile because Drop reads/sets these from another thread.
+    private volatile boolean executing;
+    private volatile boolean doNotExecute;
+
+    private Handler handler;
+
+    // State for a single-location request. If a new fix is slow we fall back to the newest cached
+    // one, and we never hand back a fix older than one we already showed.
+    private boolean oneShotMode;        // only used on API 26-29, where the fix comes via onLocationChanged
+    private Location fallback;          // newest cached fix when the request started (may be null)
+    private long lastDeliveredTime;     // getTime() of the newest fix we've handed back, or -1
+    private Runnable graceRunnable;
+    private boolean gracePending;
+    private Runnable giveUpRunnable;
+    private boolean giveUpPending;
 
     /*
      * The name and signature of this function must be kept in sync with `RUST_CALLBACK_NAME`, and
      * `RUST_CALLBACK_SIGNATURE` respectively.
      */
-    private native void rustCallback(long handlerPtrHigh, long handlerPtrLow, Location location);
+    private native void rustCallback(long sharedPtr, Location location);
 
-    public LocationCallback(long handlerPtrHigh, long handlerPtrLow) {
-        this.handlerPtrHigh = handlerPtrHigh;
-        this.handlerPtrLow = handlerPtrLow;
+    public LocationCallback(long sharedPtr) {
+        this.sharedPtr = sharedPtr;
         this.executing = false;
         this.doNotExecute = false;
     }
@@ -37,22 +64,59 @@ public class LocationCallback implements Consumer<Location>, LocationListener {
 
     public void disableExecution() {
         this.doNotExecute = true;
+        cancelGrace();
+        cancelGiveUp();
+    }
+
+    // Hand a location (or null) to Rust. `executing` lets Drop wait for us instead of freeing us mid-call.
+    private void deliver(Location location) {
+        this.executing = true;
+        if (!this.doNotExecute) {
+            rustCallback(this.sharedPtr, location);
+        }
+        this.executing = false;
+    }
+
+    // Only hand it back if it's newer than the last one, so the location never jumps back in time.
+    private void deliverIfNewer(Location location) {
+        if (location == null || location.getTime() <= lastDeliveredTime) {
+            return;
+        }
+        lastDeliveredTime = location.getTime();
+        deliver(location);
+    }
+
+    private static Location newer(Location a, Location b) {
+        if (a == null) return b;
+        if (b == null) return a;
+        return a.getTime() >= b.getTime() ? a : b;
+    }
+
+    // Finish the request with the newer of the new fix and the cached one, or null (an error) if we got neither.
+    private void resolveOneShot(Location fresh) {
+        Location best = newer(fresh, fallback);
+        if (best != null) {
+            deliverIfNewer(best);
+        } else if (lastDeliveredTime < 0L) {
+            deliver(null);
+        }
     }
 
     public void accept(Location location) {
-        this.executing = true;
-        if (!this.doNotExecute) {
-                rustCallback(this.handlerPtrHigh, this.handlerPtrLow, location);
-        }
-        this.executing = false;
+        // This is the getCurrentLocation result (API 30+); the request is done.
+        cancelGrace();
+        cancelGiveUp();
+        resolveOneShot(location);
     }
 
     public void onLocationChanged(Location location) {
-        this.executing = true;
-        if (!this.doNotExecute) {
-                rustCallback(this.handlerPtrHigh, this.handlerPtrLow, location);
+        if (oneShotMode) {
+            cancelGrace();
+            cancelGiveUp();
+            resolveOneShot(location);
+        } else {
+            deliver(location); // continuous updates: just pass every fix along
         }
-        this.executing = false;
     }
 
     // NOTE: Technically implementing this function shouldn't be necessary as it has a default implementation
@@ -63,9 +127,193 @@ public class LocationCallback implements Consumer<Location>, LocationListener {
         this.executing = true;
         if (!this.doNotExecute) {
                 for (Location location : locations) {
-                    rustCallback(this.handlerPtrHigh, this.handlerPtrLow, location);
+                    rustCallback(this.sharedPtr, location);
                 }
         }
         this.executing = false;
+    }
+
+    // These need empty overrides too, same reason as onLocationChanged(List) above: otherwise d8
+    // generates $-CC stubs that crash when Android calls them.
+    public void onProviderEnabled(String provider) {}
+    public void onProviderDisabled(String provider) {}
+    public void onStatusChanged(String provider, int status, android.os.Bundle extras) {}
+    public void onFlushComplete(int requestCode) {}
+
+    /*
+     * We fetch location with the newest API the device supports (checked with SDK_INT), down to API
+     * 26. Each version-specific call lives in its own method so older devices never try to verify the
+     * newer ones.
+     */
+
+    // preciseGranted means we have FINE permission. Only then is a new fix fast enough to wait for.
+    public boolean requestSingleLocation(LocationManager manager, boolean preciseGranted) {
+        cancelGrace();
+        cancelGiveUp();
+        lastDeliveredTime = -1L;
+        fallback = bestLastKnown(manager);
+
+        boolean started;
+        try {
+            started = startFreshFix(manager, preciseGranted);
+        } catch (RuntimeException ignored) {
+            started = false; // e.g. permission got revoked mid-call; we'll fall back to the cached fix
+        }
+
+        if (fallback != null) {
+            // Show the cached fix right away if it's recent, there's no new request coming, or we
+            // only have coarse permission. Otherwise wait a moment to see if a new one beats it.
+            long age = System.currentTimeMillis() - fallback.getTime();
+            boolean showNow = !started || !preciseGranted || age < FRESH_ENOUGH_MILLIS;
+            scheduleGrace(showNow ? 0L : GRACE_MILLIS);
+        }
+        if (started) {
+            long timeout = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
+                    ? CURRENT_BACKSTOP_MILLIS
+                    : CLASSIC_GIVE_UP_MILLIS;
+            scheduleGiveUp(manager, timeout);
+        }
+        return started || fallback != null;
+    }
+
+    // Kick off a request for a new fix, trying the newest API first. Returns false if no provider is on.
+    private boolean startFreshFix(LocationManager manager, boolean preciseGranted) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            getCurrentLocation(manager, LocationManager.FUSED_PROVIDER); // API 31+
+            return true;
+        }
+        String provider = bestProvider(manager, preciseGranted);
+        if (provider == null) {
+            return false;
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            getCurrentLocation(manager, provider); // API 30
+        } else {
+            oneShotMode = true; // on 26-29 the fix arrives via onLocationChanged, which finishes the request
+            manager.requestSingleUpdate(provider, this, Looper.getMainLooper());
+        }
+        return true;
+    }
+
+    // The most recent cached fix from any provider (null if there's none). FUSED_PROVIDER only exists on API 31+.
+    private static Location bestLastKnown(LocationManager manager) {
+        String[] providers = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+                ? new String[] { LocationManager.FUSED_PROVIDER, LocationManager.GPS_PROVIDER, LocationManager.NETWORK_PROVIDER }
+                : new String[] { LocationManager.GPS_PROVIDER, LocationManager.NETWORK_PROVIDER };
+        Location best = null;
+        for (String provider : providers) {
+            try {
+                best = newer(best, manager.getLastKnownLocation(provider));
+            } catch (SecurityException | IllegalArgumentException ignored) {
+                // this provider isn't allowed or isn't on the device; skip it
+            }
+        }
+        return best;
+    }
+
+    // After a delay, hand back the cached fix — unless a new one shows up first and cancels this.
+    private void scheduleGrace(long delayMillis) {
+        cancelGrace();
+        gracePending = true;
+        ensureHandler();
+        graceRunnable = () -> {
+            if (!gracePending) {
+                return;
+            }
+            gracePending = false;
+            deliverIfNewer(fallback);
+        };
+        handler.postDelayed(graceRunnable, delayMillis);
+    }
+
+    private void cancelGrace() {
+        if (gracePending) {
+            gracePending = false;
+            if (handler != null && graceRunnable != null) {
+                handler.removeCallbacks(graceRunnable);
+            }
+        }
+    }
+
+    // Last resort if the new fix takes too long: stop listening and finish with the cached fix, or an error.
+    private void scheduleGiveUp(LocationManager manager, long delayMillis) {
+        cancelGiveUp();
+        giveUpPending = true;
+        ensureHandler();
+        giveUpRunnable = () -> {
+            if (!giveUpPending) {
+                return;
+            }
+            giveUpPending = false;
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+                manager.removeUpdates(this); // only on 26-29; on 30+ this would stop a running continuous stream
+            }
+            cancelGrace();
+            resolveOneShot(null);
+        };
+        handler.postDelayed(giveUpRunnable, delayMillis);
+    }
+
+    private void cancelGiveUp() {
+        if (giveUpPending) {
+            giveUpPending = false;
+            if (handler != null && giveUpRunnable != null) {
+                handler.removeCallbacks(giveUpRunnable);
+            }
+        }
+    }
+
+    // Start continuous location updates. Returns false if no provider is on.
+    public boolean startLocationUpdates(LocationManager manager, long intervalMillis, boolean preciseGranted) {
+        cancelGrace(); // a continuous stream takes over from any single request still in progress
+        cancelGiveUp();
+        oneShotMode = false;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            requestFusedUpdates(manager, intervalMillis); // API 31+
+            return true;
+        }
+        String provider = bestProvider(manager, preciseGranted);
+        if (provider == null) {
+            return false;
+        }
+        manager.requestLocationUpdates(provider, intervalMillis, 0f, this, Looper.getMainLooper());
+        return true;
+    }
+
+    public void stopLocationUpdates(LocationManager manager) {
+        manager.removeUpdates(this);
+    }
+
+    // In its own method because getCurrentLocation is API 30+.
+    private void getCurrentLocation(LocationManager manager, String provider) {
+        manager.getCurrentLocation(provider, null, mainThreadExecutor(), this);
+    }
+
+    // In its own method because LocationRequest.Builder and the fused provider are API 31+.
+    private void requestFusedUpdates(LocationManager manager, long intervalMillis) {
+        android.location.LocationRequest request =
+                new android.location.LocationRequest.Builder(intervalMillis).build();
+        manager.requestLocationUpdates(
+                LocationManager.FUSED_PROVIDER, request, mainThreadExecutor(), this);
+    }
+
+    // Pick the best provider that's on. With coarse-only permission use NETWORK — GPS needs FINE and would throw.
+    private static String bestProvider(LocationManager manager, boolean preciseGranted) {
+        if (!preciseGranted && manager.isProviderEnabled(LocationManager.NETWORK_PROVIDER)) {
+            return LocationManager.NETWORK_PROVIDER;
+        }
+        return manager.getBestProvider(new Criteria(), true);
+    }
+
+    private void ensureHandler() {
+        if (handler == null) {
+            handler = new Handler(Looper.getMainLooper());
+        }
+    }
+
+    private Executor mainThreadExecutor() {
+        ensureHandler();
+        Handler h = handler;
+        return command -> h.post(command);
     }
 }

--- a/crates/location/src/sys/android/LocationPermissionFragment.java
+++ b/crates/location/src/sys/android/LocationPermissionFragment.java
@@ -1,0 +1,181 @@
+/* This file is compiled by build.rs. */
+
+package robius.location;
+
+import android.app.Activity;
+import android.app.Fragment;
+import android.app.FragmentManager;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+
+/*
+ * Headless fragment for the runtime permission request. Fragment.requestPermissions sends the result
+ * straight back here, so we don't have to touch the activity's own onRequestPermissionsResult. Nothing
+ * here blocks, since the Rust caller might be on a thread that must never wait on the Android UI thread.
+ */
+public class LocationPermissionFragment extends Fragment {
+    // Must be <= 0xffff: android.app.Fragment encodes its index in the upper 16 bits of the code.
+    private static final int REQUEST_CODE = 0x4c6f;
+    private static final String TAG = "robius.location.LocationPermissionFragment";
+
+    // Raw pointer to a Rust `Arc<Shared>` ref. 0 means no callback — a recreated instance, or we already delivered.
+    private long callbackPtr;
+    private String[] perms;
+    private boolean launched;
+
+    /*
+     * The name and signature of this function must be kept in sync with
+     * `PERMISSION_CALLBACK_NAME` and `PERMISSION_CALLBACK_SIGNATURE` in `callback.rs`.
+     */
+    private static native void rustPermissionCallback(long callbackPtr, boolean granted);
+
+    // The framework needs this to recreate the fragment (e.g. after the process dies). A recreated
+    // one has no callback pointer and just removes itself in `onResume`.
+    public LocationPermissionFragment() {
+        this.callbackPtr = 0;
+        this.perms = null;
+        this.launched = false;
+    }
+
+    private LocationPermissionFragment(long callbackPtr, String[] perms) {
+        this.callbackPtr = callbackPtr;
+        this.perms = perms;
+        this.launched = false;
+    }
+
+    // Attaches the fragment and asks for `perms`. Doesn't block — posts to the UI thread and returns.
+    // Java owns `callbackPtr` now and always delivers it exactly once (from the fragment's result or
+    // `onDestroy`, or from a failure here).
+    public static void show(Activity activity, long callbackPtr, String[] perms) {
+        activity.runOnUiThread(() -> showOnUiThread(activity, callbackPtr, perms));
+    }
+
+    private static void showOnUiThread(Activity activity, long callbackPtr, String[] perms) {
+        // Once the fragment owns the pointer, only it delivers the callback, so we deliver just once.
+        // Before that, we deliver here if anything fails.
+        boolean fragmentOwnsPtr = false;
+        try {
+            if (activity.isFinishing() || activity.isDestroyed()) {
+                rustPermissionCallback(callbackPtr, false);
+                return;
+            }
+
+            FragmentManager fm = activity.getFragmentManager();
+            Fragment existing = fm.findFragmentByTag(TAG);
+            if (existing instanceof LocationPermissionFragment) {
+                if (((LocationPermissionFragment) existing).hasCallback()) {
+                    // Another request is already in flight; drop this duplicate.
+                    rustPermissionCallback(callbackPtr, false);
+                    return;
+                }
+                // Remove any old leftover before adding a fresh one.
+                fm.beginTransaction().remove(existing).commitNowAllowingStateLoss();
+            }
+
+            LocationPermissionFragment fragment = new LocationPermissionFragment(callbackPtr, perms);
+            fragmentOwnsPtr = true;
+            // Commit async so this can't throw right here and race the fragment's own delivery.
+            fm.beginTransaction().add(fragment, TAG).commitAllowingStateLoss();
+        } catch (Throwable t) {
+            if (!fragmentOwnsPtr) {
+                rustPermissionCallback(callbackPtr, false);
+            }
+            // Else the fragment owns the pointer and its onDestroy will deliver.
+        }
+    }
+
+    // Removes any in-flight fragment (called when the `Manager` is dropped mid-request). Its
+    // `onDestroy` delivers "denied" and frees the Rust ref (does nothing if a result already came in).
+    public static void removeExisting(Activity activity) {
+        activity.runOnUiThread(() -> {
+            try {
+                if (activity.isFinishing() || activity.isDestroyed()) {
+                    return;
+                }
+                FragmentManager fm = activity.getFragmentManager();
+                Fragment existing = fm.findFragmentByTag(TAG);
+                if (existing instanceof LocationPermissionFragment) {
+                    fm.beginTransaction().remove(existing).commitNowAllowingStateLoss();
+                }
+            } catch (Throwable ignored) {}
+        });
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        // Survive rotation as the same instance, so the pending request keeps its callback pointer.
+        setRetainInstance(true);
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        // A framework-recreated instance has no callback, so it shouldn't stick around.
+        if (callbackPtr == 0) {
+            removeSelf();
+            return;
+        }
+
+        if (!launched && perms != null) {
+            launched = true;
+            // Use the Fragment's own `requestPermissions` so the result routes back to us.
+            requestPermissions(perms, REQUEST_CODE);
+        }
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+        if (requestCode != REQUEST_CODE) {
+            return;
+        }
+
+        // Granted if ANY requested permission was granted (e.g. "Approximate" grants COARSE, denies
+        // FINE). An empty array (an interrupted request) counts as denied.
+        boolean granted = false;
+        for (int result : grantResults) {
+            if (result == PackageManager.PERMISSION_GRANTED) {
+                granted = true;
+                break;
+            }
+        }
+
+        deliver(granted);
+        removeSelf();
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+
+        // A config change recreates us from the retained instance, so don't fire a spurious "denied".
+        Activity activity = getActivity();
+        if (activity != null && activity.isChangingConfigurations()) {
+            return;
+        }
+
+        // Real teardown before a result: deliver "denied" so the callback always runs exactly once
+        // and the Rust ref gets freed (does nothing if already delivered, since `deliver` claims it).
+        deliver(false);
+    }
+
+    private synchronized boolean hasCallback() {
+        return callbackPtr != 0;
+    }
+
+    private synchronized void deliver(boolean granted) {
+        long ptr = callbackPtr;
+        callbackPtr = 0;
+        if (ptr != 0) {
+            rustPermissionCallback(ptr, granted);
+        }
+    }
+
+    private void removeSelf() {
+        FragmentManager fm = getFragmentManager();
+        if (fm != null) {
+            fm.beginTransaction().remove(this).commitAllowingStateLoss();
+        }
+    }
+}

--- a/crates/location/src/sys/android/callback.rs
+++ b/crates/location/src/sys/android/callback.rs
@@ -1,12 +1,17 @@
-use std::{marker::PhantomData, sync::OnceLock};
+use std::{
+    marker::PhantomData,
+    panic::{catch_unwind, AssertUnwindSafe},
+    sync::{atomic::Ordering, Arc, OnceLock},
+};
 
 use jni::{
     objects::{GlobalRef, JClass, JObject, JValueGen},
-    sys::jlong,
+    sys::{jboolean, jlong},
     JNIEnv, NativeMethod,
 };
 
-use crate::Result;
+use super::Shared;
+use crate::{Error, Result};
 
 const CALLBACK_BYTECODE: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/classes.dex"));
 
@@ -14,65 +19,145 @@ const CALLBACK_BYTECODE: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/class
 const RUST_CALLBACK_NAME: &str = "rustCallback";
 // NOTE: This must be kept in sync with the signature of `rust_callback`, and
 // the signature specified in `LocationCallback.java`.
-const RUST_CALLBACK_SIGNATURE: &str = "(JJLandroid/location/Location;)V";
+const RUST_CALLBACK_SIGNATURE: &str = "(JLandroid/location/Location;)V";
+
+// NOTE: This must be kept in sync with `LocationPermissionFragment.java`.
+const PERMISSION_CALLBACK_NAME: &str = "rustPermissionCallback";
+// NOTE: This must be kept in sync with the signature of `rust_permission_callback`, and
+// the signature specified in `LocationPermissionFragment.java`.
+const PERMISSION_CALLBACK_SIGNATURE: &str = "(JZ)V";
 
 // NOTE: The signature of this function must be kept in sync with
 // `RUST_CALLBACK_SIGNATURE`.
 unsafe extern "C" fn rust_callback<'a>(
     env: JNIEnv<'a>,
     _: JObject<'a>,
-    handler_ptr_high: jlong,
-    handler_ptr_low: jlong,
+    shared_ptr: jlong,
     location: JObject<'a>,
 ) {
-    // TODO: 32-bit? What's that?
     #[cfg(not(target_pointer_width = "64"))]
-    compiler_error!("non-64-bit Android targets are not supported");
+    compile_error!("non-64-bit Android targets are not supported");
 
-    let handler_ptr: *const super::InnerHandler =
-        unsafe { std::mem::transmute([handler_ptr_high, handler_ptr_low]) };
-    // SAFETY: See `Drop` implementation for `sys::android::Manager`.
-    let handler = unsafe { &*handler_ptr };
-
-    if let Ok(handler) = handler.lock() {
-        let location = crate::Location {
-            inner: super::Location {
-                inner: env.new_global_ref(location).unwrap(),
-                phantom: PhantomData,
-            },
-        };
-        handler.handle(location);
+    if shared_ptr == 0 {
+        return;
     }
+
+    // SAFETY: the Java `LocationCallback` owns an `Arc<Shared>` ref that's only freed in `drop`, after
+    // this callback has finished, so the pointer stays valid. We only take a shared reference.
+    let shared = unsafe { &*(shared_ptr as *const Shared) };
+
+    // A panic must never unwind across the JNI boundary.
+    let _ = catch_unwind(AssertUnwindSafe(|| deliver_location(env, shared, location)));
+}
+
+fn deliver_location(env: JNIEnv<'_>, shared: &Shared, location: JObject<'_>) {
+    // `getCurrentLocation` delivers `null` when it can't get a fresh fix; fall back to the last
+    // known location before giving up.
+    if location.as_raw().is_null() {
+        super::deliver_last_known_or_error(shared);
+        return;
+    }
+
+    let global = match env.new_global_ref(&location) {
+        Ok(global) => global,
+        Err(_) => {
+            let _ = env.exception_clear();
+            shared.handler.error(Error::Unknown);
+            return;
+        }
+    };
+
+    let location = crate::Location {
+        inner: super::Location {
+            inner: global,
+            phantom: PhantomData,
+        },
+    };
+    shared.handler.handle(location);
+}
+
+// NOTE: The signature of this function must be kept in sync with
+// `PERMISSION_CALLBACK_SIGNATURE`.
+unsafe extern "C" fn rust_permission_callback<'a>(
+    _env: JNIEnv<'a>,
+    _: JObject<'a>,
+    callback_ptr: jlong,
+    granted: jboolean,
+) {
+    if callback_ptr == 0 {
+        return;
+    }
+
+    // SAFETY: this came from `Arc::into_raw` in `request_authorization`, and the fragment calls this
+    // callback exactly once, so we take back exactly one strong reference here.
+    let shared = unsafe { Arc::from_raw(callback_ptr as *const Shared) };
+
+    // If the `Manager` is gone, drop the reference we took back without touching the handler.
+    if !shared.dropped.load(Ordering::SeqCst) {
+        let _ = catch_unwind(AssertUnwindSafe(|| {
+            super::handle_permission_result(&shared, granted != 0);
+        }));
+    }
+    // `shared` (the strong reference we took back) is dropped here.
 }
 
 static CALLBACK_CLASS: OnceLock<GlobalRef> = OnceLock::new();
+static PERMISSION_FRAGMENT_CLASS: OnceLock<GlobalRef> = OnceLock::new();
 
 pub(super) fn get_callback_class(env: &mut JNIEnv<'_>) -> Result<&'static GlobalRef> {
     // TODO: This can be optimised when the `once_cell_try` feature is stabilised.
-
     if let Some(class) = CALLBACK_CLASS.get() {
         return Ok(class);
     }
-    let callback_class = load_callback_class(env)?;
-    register_rust_callback(env, &callback_class)?;
-    let global = env.new_global_ref(callback_class)?;
+    let class = load_class(env, "robius.location.LocationCallback")?;
+    register_native_method(
+        env,
+        &class,
+        RUST_CALLBACK_NAME,
+        RUST_CALLBACK_SIGNATURE,
+        rust_callback as *mut _,
+    )?;
+    let global = env.new_global_ref(class)?;
 
     Ok(CALLBACK_CLASS.get_or_init(|| global))
 }
 
-fn register_rust_callback<'a>(env: &mut JNIEnv<'a>, callback_class: &JClass<'a>) -> Result<()> {
+pub(super) fn get_permission_fragment_class(env: &mut JNIEnv<'_>) -> Result<&'static GlobalRef> {
+    if let Some(class) = PERMISSION_FRAGMENT_CLASS.get() {
+        return Ok(class);
+    }
+    let class = load_class(env, "robius.location.LocationPermissionFragment")?;
+    register_native_method(
+        env,
+        &class,
+        PERMISSION_CALLBACK_NAME,
+        PERMISSION_CALLBACK_SIGNATURE,
+        rust_permission_callback as *mut _,
+    )?;
+    let global = env.new_global_ref(class)?;
+
+    Ok(PERMISSION_FRAGMENT_CLASS.get_or_init(|| global))
+}
+
+fn register_native_method<'a>(
+    env: &mut JNIEnv<'a>,
+    class: &JClass<'a>,
+    name: &str,
+    signature: &str,
+    fn_ptr: *mut std::ffi::c_void,
+) -> Result<()> {
     env.register_native_methods(
-        callback_class,
+        class,
         &[NativeMethod {
-            name: RUST_CALLBACK_NAME.into(),
-            sig: RUST_CALLBACK_SIGNATURE.into(),
-            fn_ptr: rust_callback as *mut _,
+            name: name.into(),
+            sig: signature.into(),
+            fn_ptr,
         }],
     )
     .map_err(|e| e.into())
 }
 
-fn load_callback_class<'a>(env: &mut JNIEnv<'a>) -> Result<JClass<'a>> {
+fn load_class<'a>(env: &mut JNIEnv<'a>, class_name: &str) -> Result<JClass<'a>> {
     const IN_MEMORY_LOADER: &str = "dalvik/system/InMemoryDexClassLoader";
 
     let byte_buffer = unsafe {
@@ -80,26 +165,31 @@ fn load_callback_class<'a>(env: &mut JNIEnv<'a>) -> Result<JClass<'a>> {
             CALLBACK_BYTECODE.as_ptr() as *mut u8,
             CALLBACK_BYTECODE.len(),
         )
-    }?;
+    }
+    .map_err(|e| super::map_android_error(env, e))?;
 
-    let dex_class_loader = env.new_object(
-        IN_MEMORY_LOADER,
-        "(Ljava/nio/ByteBuffer;Ljava/lang/ClassLoader;)V",
-        &[
-            JValueGen::Object(&JObject::from(byte_buffer)),
-            JValueGen::Object(&JObject::null()),
-        ],
-    )?;
+    let dex_class_loader = env
+        .new_object(
+            IN_MEMORY_LOADER,
+            "(Ljava/nio/ByteBuffer;Ljava/lang/ClassLoader;)V",
+            &[
+                JValueGen::Object(&JObject::from(byte_buffer)),
+                JValueGen::Object(&JObject::null()),
+            ],
+        )
+        .map_err(|e| super::map_android_error(env, e))?;
 
+    let class_name = env
+        .new_string(class_name)
+        .map_err(|e| super::map_android_error(env, e))?;
     Ok(env
         .call_method(
             &dex_class_loader,
             "loadClass",
             "(Ljava/lang/String;)Ljava/lang/Class;",
-            &[JValueGen::Object(&JObject::from(
-                env.new_string("robius.location.LocationCallback").unwrap(),
-            ))],
-        )?
+            &[JValueGen::Object(&JObject::from(class_name))],
+        )
+        .map_err(|e| super::map_android_error(env, e))?
         .l()?
         .into())
 }

--- a/crates/location/src/sys/android/mod.rs
+++ b/crates/location/src/sys/android/mod.rs
@@ -2,25 +2,53 @@ mod callback;
 
 use std::{
     marker::PhantomData,
-    sync::Mutex,
+    panic::{catch_unwind, AssertUnwindSafe},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex, OnceLock, PoisonError,
+    },
     time::{Duration, SystemTime},
 };
 
 use jni::{
+    errors::Error as JniError,
     objects::{GlobalRef, JObject, JValueGen},
+    sys::jlong,
     JNIEnv,
 };
 
 use crate::{Access, Accuracy, Coordinates, Error, Handler, Result};
 
-type InnerHandler = Mutex<dyn Handler>;
+const COARSE_LOCATION_PERMISSION: &str = "android.permission.ACCESS_COARSE_LOCATION";
+const FINE_LOCATION_PERMISSION: &str = "android.permission.ACCESS_FINE_LOCATION";
+const PERMISSION_GRANTED: i32 = 0;
+
+/// Shared via `Arc` with the Java `LocationCallback` and permission fragment. Each raw `Arc` ref we
+/// hand to Java gets freed exactly once, and everything runs on the main thread.
+pub(super) struct Shared {
+    handler: Box<dyn Handler>,
+    /// The Java `LocationCallback`. Set once in `new`, before any callback could use it.
+    callback: OnceLock<GlobalRef>,
+    /// Requests we're holding until the user grants permission.
+    pending: Mutex<Pending>,
+    /// Accuracy from the last `request_authorization`, reused when we prompt on our own.
+    accuracy: Mutex<Accuracy>,
+    /// Whether a permission request is currently in flight.
+    requesting: AtomicBool,
+    /// Set on drop; a late permission result must then not touch the handler.
+    dropped: AtomicBool,
+}
+
+#[derive(Default)]
+struct Pending {
+    update_once: bool,
+    start_updates: bool,
+}
 
 pub struct Manager {
-    callback: GlobalRef,
-    // We "leak" the handler so that `rust_callback` can safely access it, and then when dropping
-    // the manager we make sure that `rust_callback` will never be called again before reboxing
-    // (and hence deallocating) the handler. See the `Drop` implementation for more details.
-    inner: *const InnerHandler,
+    shared: Arc<Shared>,
+    /// The `Arc` ref we handed to the Java `LocationCallback`; freed once in `drop`.
+    location_callback_ptr: *const Shared,
 }
 
 impl Manager {
@@ -28,38 +56,52 @@ impl Manager {
     where
         T: Handler,
     {
-        let inner = Box::into_raw(Box::new(Mutex::new(handler)));
+        let shared = Arc::new(Shared {
+            handler: Box::new(handler),
+            callback: OnceLock::new(),
+            pending: Mutex::new(Pending::default()),
+            accuracy: Mutex::new(Accuracy::Precise),
+            requesting: AtomicBool::new(false),
+            dropped: AtomicBool::new(false),
+        });
+
+        // An owning `Arc` ref for the Java `LocationCallback`; freed in `drop`.
+        let location_callback_ptr = Arc::into_raw(shared.clone());
+
+        let global = robius_android_env::with_activity(|env, _| {
+            let callback = construct_callback(env, location_callback_ptr)?;
+            env.new_global_ref(callback).map_err(Error::from)
+        })
+        .map_err(|_| Error::AndroidEnvironment)
+        .and_then(|x| x);
+
+        let global = match global {
+            Ok(global) => global,
+            Err(error) => {
+                // SAFETY: Java never took the pointer, so free the `into_raw` ref here, just once.
+                unsafe { drop(Arc::from_raw(location_callback_ptr)) };
+                return Err(error);
+            }
+        };
+
+        // Set before the `Manager` (and so any callback) can be used.
+        let _ = shared.callback.set(global);
 
         Ok(Manager {
-            callback: robius_android_env::with_activity(|env, _| {
-                let callback = construct_callback(env, inner)?;
-                env.new_global_ref(callback).map_err(|e| e.into())
-            })
-            .map_err(|_| Error::AndroidEnvironment)
-            .and_then(|x| x)?,
-            inner,
+            shared,
+            location_callback_ptr,
         })
     }
 
     pub fn request_authorization(&self, _access: Access, accuracy: Accuracy) -> Result<()> {
-        robius_android_env::with_activity(|env, current_activity| {
-            let permissions = env.new_string(match accuracy {
-                Accuracy::Approximate => "android.permission.ACCESS_COARSE_LOCATION",
-                Accuracy::Precise => "android.permission.ACCESS_FINE_LOCATION",
-            })?;
-
-            let array = env.new_object_array(1, "java/lang/String", permissions)?;
-            // TODO: Ideally we would provide functionality to wait for for authorization.
-            let request_code = 3;
-
-            env.call_method(
-                current_activity,
-                "requestPermissions",
-                "([Ljava/lang/String;I)V",
-                &[JValueGen::Object(&array), JValueGen::Int(request_code)],
-            )?;
-
-            Ok(())
+        *self.accuracy_slot() = accuracy;
+        robius_android_env::with_activity(|env, activity| {
+            // Already allowed (coarse or fine)? Nothing to ask for. Coarse-only counts as enough even
+            // for a `Precise` request, so we don't nag the user every call.
+            if has_location_permission(env, activity)? {
+                return Ok(());
+            }
+            self.launch_permission_request(env, activity, accuracy)
         })
         .map_err(|_| Error::AndroidEnvironment)
         .and_then(|x| x)
@@ -67,24 +109,13 @@ impl Manager {
 
     pub fn update_once(&self) -> Result<()> {
         robius_android_env::with_activity(|env, context| {
-            let manager = get_location_manager(env, context)?;
-            let provider = env.new_string("fused")?;
-            let executor = get_executor(env, context)?;
-
-            env.call_method(
-                manager,
-                "getCurrentLocation",
-                "(Ljava/lang/String;Landroid/os/CancellationSignal;Ljava/util/concurrent/Executor;\
-                 Ljava/util/function/Consumer;)V",
-                &[
-                    JValueGen::Object(&provider),
-                    JValueGen::Object(&JObject::null()),
-                    JValueGen::Object(&executor),
-                    JValueGen::Object(&self.callback),
-                ],
-            )?;
-
-            Ok(())
+            if has_location_permission(env, context)? {
+                run_update_once(env, context, &self.shared)
+            } else {
+                // Hold it and (re-)ask, so a request made while denied or undecided can still go through.
+                self.pending().update_once = true;
+                self.launch_permission_request(env, context, self.accuracy())
+            }
         })
         .map_err(|_| Error::AndroidEnvironment)
         .and_then(|x| x)
@@ -92,151 +123,416 @@ impl Manager {
 
     pub fn start_updates(&self) -> Result<()> {
         robius_android_env::with_activity(|env, context| {
-            let manager = get_location_manager(env, context)?;
-            let provider = env.new_string("fused")?;
-            let request = construct_location_request(env)?;
-            let executor = get_executor(env, context)?;
-
-            env.call_method(
-                manager,
-                "requestLocationUpdates",
-                "(Ljava/lang/String;Landroid/location/LocationRequest;Ljava/util/concurrent/\
-                 Executor;Landroid/location/LocationListener;)V",
-                &[
-                    JValueGen::Object(&provider),
-                    JValueGen::Object(&request),
-                    JValueGen::Object(&executor),
-                    JValueGen::Object(&self.callback),
-                ],
-            )?;
-
-            Ok(())
+            if has_location_permission(env, context)? {
+                run_start_updates(env, context, &self.shared)
+            } else {
+                // Hold it and (re-)ask, so a request made while denied or undecided can still go through.
+                self.pending().start_updates = true;
+                self.launch_permission_request(env, context, self.accuracy())
+            }
         })
         .map_err(|_| Error::AndroidEnvironment)
         .and_then(|x| x)
     }
 
     pub fn stop_updates(&self) -> Result<()> {
-        robius_android_env::with_activity(|env, context| {
-            let manager = get_location_manager(env, context)?;
-            env.call_method(
-                manager,
-                "removeUpdates",
-                "(Landroid/location/LocationListener;)V",
-                &[JValueGen::Object(&self.callback)],
-            )?;
-            Ok(())
-        })
-        .map_err(|_| Error::AndroidEnvironment)
-        .and_then(|x| x)
+        // Cancel a deferred `start_updates` so a later grant doesn't start updates after a stop.
+        self.pending().start_updates = false;
+
+        robius_android_env::with_activity(|env, context| run_remove_updates(env, context, &self.shared))
+            .map_err(|_| Error::AndroidEnvironment)
+            .and_then(|x| x)
+    }
+
+    fn pending(&self) -> std::sync::MutexGuard<'_, Pending> {
+        self.shared.pending.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    fn accuracy_slot(&self) -> std::sync::MutexGuard<'_, Accuracy> {
+        self.shared.accuracy.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    fn accuracy(&self) -> Accuracy {
+        *self.accuracy_slot()
+    }
+
+    /// Shows the permission dialog unless one is already in flight. The `requesting` flag makes it
+    /// idempotent, so two callers asking at once still show only one dialog.
+    fn launch_permission_request(
+        &self,
+        env: &mut JNIEnv<'_>,
+        activity: &JObject<'_>,
+        accuracy: Accuracy,
+    ) -> Result<()> {
+        if self.shared.requesting.swap(true, Ordering::SeqCst) {
+            return Ok(());
+        }
+
+        let permissions = match accuracy {
+            Accuracy::Approximate => &[COARSE_LOCATION_PERMISSION][..],
+            // Android 12+ ignores fine-only runtime requests, so ask for both and let the system show
+            // the precise/approximate choice in one dialog.
+            Accuracy::Precise => &[COARSE_LOCATION_PERMISSION, FINE_LOCATION_PERMISSION][..],
+        };
+
+        let array = match permission_array(env, permissions) {
+            Ok(array) => array,
+            Err(error) => {
+                self.shared.requesting.store(false, Ordering::SeqCst);
+                return Err(error);
+            }
+        };
+
+        // `show` doesn't block; Java now owns `ptr` and will call the callback once. Only free `ptr`
+        // here if the JNI call itself failed, so Java never got it.
+        let ptr = Arc::into_raw(self.shared.clone());
+        match launch_permission_fragment(env, activity, ptr as jlong, &array) {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                // SAFETY: `ptr` came from `Arc::into_raw` and Java never got it, so free it once.
+                unsafe { drop(Arc::from_raw(ptr)) };
+                self.shared.requesting.store(false, Ordering::SeqCst);
+                Err(error)
+            }
+        }
     }
 }
 
 impl Drop for Manager {
     fn drop(&mut self) {
-        // NOTE: We want to unwrap in this function as otherwise could lead to memory
-        // unsafety.
+        // Silence any late permission result first, so it can't touch the handler.
+        self.shared.dropped.store(true, Ordering::SeqCst);
 
-        // From https://developer.android.com/reference/android/location/LocationManager#removeUpdates(android.location.LocationListener):
-        // The given listener is guaranteed not to receive any invocations that
-        // happens-after this method is invoked.
-        self.stop_updates().unwrap();
+        // Clean up as best we can (Drop must not panic). Draining the callback makes sure it's
+        // finished, so it's safe to free its `Arc` ref below.
+        let drained = robius_android_env::with_activity(|env, context| {
+            let _ = run_remove_updates(env, context, &self.shared);
 
-        // This is just to avoid some funky race conditions with the Java function. By
-        // using two variables we ensure that if our check happens to occur
-        // between the function start and `this.executing = true` (in e.g.
-        // `onLocationChanged`), `rustCallback` still won't be called. This could
-        // probably be done more efficiently in Rust using atomics.
-        robius_android_env::with_activity(|env, _| {
-            env.call_method(&self.callback, "disableExecution", "()V", &[])
-                .unwrap();
+            if let Some(callback) = self.shared.callback.get() {
+                // `removeUpdates` stops future callbacks; `disableExecution` blocks one already queued.
+                let _ = env.call_method(callback, "disableExecution", "()V", &[]);
+
+                // Wait for any `rust_callback` still running (usually already finished on the main thread).
+                while let Ok(true) = env
+                    .call_method(callback, "isExecuting", "()Z", &[])
+                    .and_then(|value| value.z())
+                {}
+            }
+
+            // Remove any in-flight fragment, so its `onDestroy` frees its `Arc` ref right away.
+            if self.shared.requesting.load(Ordering::SeqCst) {
+                let _ = remove_permission_fragment(env, context);
+            }
         })
-        .unwrap();
+        .is_ok();
 
-        // So now we are mostly ok to drop the handler except for the fact that a
-        // `rust_callback` invocation may currently be executing. Hence, we have to keep
-        // track of that (in Java).
-        let mut executing = true;
-
-        while executing {
-            executing = robius_android_env::with_activity(|env, _| {
-                env.call_method(&self.callback, "isExecuting", "()Z", &[])?
-                    .z()
-            })
-            .unwrap()
-            .unwrap();
+        if drained {
+            // SAFETY: the drain waited for `rust_callback` to finish, so it's safe to free the `new` `into_raw` ref.
+            unsafe { drop(Arc::from_raw(self.location_callback_ptr)) };
         }
-
-        // SAFETY: We have stopped updates and so `rust_callback` will never be invoked
-        // again. Moreover we have waited for any `rust_callback` invocations to
-        // finish executing. Hence, nothing else will ever touch the data behind
-        // this pointer and so we can safely deallocate it.
-        let _ = unsafe { Box::from_raw(self.inner as *mut InnerHandler) };
+        // Otherwise the activity was gone and we couldn't make sure the callback had finished, so
+        // leaking this ref is the safe choice.
     }
 }
 
+/// Runs a held location request, sending any failure to the handler (there's no caller to return an
+/// error to).
+fn run_and_report<F>(shared: &Shared, f: F)
+where
+    F: FnOnce(&mut JNIEnv, &JObject, &Shared) -> Result<()>,
+{
+    let result = robius_android_env::with_activity(|env, context| f(env, context, shared))
+        .map_err(|_| Error::AndroidEnvironment)
+        .and_then(|x| x);
+    if let Err(error) = result {
+        report_error(shared, error);
+    }
+}
+
+/// Reports an error to the handler, catching any panic so it can't unwind across the JNI boundary.
+fn report_error(shared: &Shared, error: Error) {
+    let _ = catch_unwind(AssertUnwindSafe(|| shared.handler.error(error)));
+}
+
+/// Handles the result of a permission request (main thread, and only while the `Manager` is still alive).
+pub(super) fn handle_permission_result(shared: &Shared, granted: bool) {
+    shared.requesting.store(false, Ordering::SeqCst);
+
+    // Grab the pending flags and drop the lock before calling into JNI or the handler — the handler
+    // might call back into a `Manager` method, which would deadlock if we still held it.
+    let pending = std::mem::take(
+        &mut *shared.pending.lock().unwrap_or_else(PoisonError::into_inner),
+    );
+
+    if granted {
+        // One-shot first, so a deferred `start_updates` (continuous) wins last.
+        if pending.update_once {
+            run_and_report(shared, run_update_once);
+        }
+        if pending.start_updates {
+            run_and_report(shared, run_start_updates);
+        }
+    } else {
+        report_error(shared, Error::AuthorizationDenied);
+    }
+}
+
+fn run_update_once(env: &mut JNIEnv, context: &JObject, shared: &Shared) -> Result<()> {
+    let manager = get_location_manager(env, context)?;
+    // With fine permission the Java side can wait a moment for a new fix; coarse is too slow for that.
+    let precise = has_permission(env, context, FINE_LOCATION_PERMISSION)?;
+    let callback = location_callback(shared);
+
+    // The Java side picks the newest available API for this device (see `LocationCallback.java`).
+    let started = env
+        .call_method(
+            callback,
+            "requestSingleLocation",
+            "(Landroid/location/LocationManager;Z)Z",
+            &[JValueGen::Object(&manager), JValueGen::Bool(precise as u8)],
+        )
+        .map_err(|e| map_android_error(env, e))?
+        .z()?;
+
+    // `false` means no location provider is currently enabled.
+    if started {
+        Ok(())
+    } else {
+        Err(Error::TemporarilyUnavailable)
+    }
+}
+
+fn run_start_updates(env: &mut JNIEnv, context: &JObject, shared: &Shared) -> Result<()> {
+    let manager = get_location_manager(env, context)?;
+    // Fine permission lets the Java side pick a provider that works with the granted accuracy.
+    let precise = has_permission(env, context, FINE_LOCATION_PERMISSION)?;
+    let callback = location_callback(shared);
+
+    let started = env
+        .call_method(
+            callback,
+            "startLocationUpdates",
+            "(Landroid/location/LocationManager;JZ)Z",
+            &[JValueGen::Object(&manager), JValueGen::Long(1000), JValueGen::Bool(precise as u8)],
+        )
+        .map_err(|e| map_android_error(env, e))?
+        .z()?;
+
+    if started {
+        Ok(())
+    } else {
+        Err(Error::TemporarilyUnavailable)
+    }
+}
+
+fn run_remove_updates(env: &mut JNIEnv, context: &JObject, shared: &Shared) -> Result<()> {
+    let manager = get_location_manager(env, context)?;
+    let callback = location_callback(shared);
+    env.call_method(
+        callback,
+        "stopLocationUpdates",
+        "(Landroid/location/LocationManager;)V",
+        &[JValueGen::Object(&manager)],
+    )
+    .map_err(|e| map_android_error(env, e))?;
+    Ok(())
+}
+
+fn location_callback(shared: &Shared) -> &JObject<'static> {
+    shared
+        .callback
+        .get()
+        .expect("LocationCallback is set in Manager::new before any use")
+        .as_obj()
+}
+
+/// When `getCurrentLocation` gives us nothing: hand back the most recent cached location, or report
+/// [`Error::TemporarilyUnavailable`] if there isn't one.
+pub(super) fn deliver_last_known_or_error(shared: &Shared) {
+    let result = robius_android_env::with_activity(last_known_location)
+        .map_err(|_| Error::AndroidEnvironment)
+        .and_then(|x| x);
+
+    match result {
+        Ok(Some(location)) => {
+            let location = crate::Location {
+                inner: Location {
+                    inner: location,
+                    phantom: PhantomData,
+                },
+            };
+            shared.handler.handle(location);
+        }
+        _ => shared.handler.error(Error::TemporarilyUnavailable),
+    }
+}
+
+/// Returns the most recent cached location from any provider, if one exists.
+fn last_known_location(env: &mut JNIEnv<'_>, context: &JObject<'_>) -> Result<Option<GlobalRef>> {
+    let manager = get_location_manager(env, context)?;
+
+    for provider in ["fused", "gps", "network"] {
+        let Ok(provider) = env.new_string(provider) else {
+            let _ = env.exception_clear();
+            continue;
+        };
+        // An unregistered provider throws; treat that (and any error) as "no location" and move on.
+        let location = match env.call_method(
+            &manager,
+            "getLastKnownLocation",
+            "(Ljava/lang/String;)Landroid/location/Location;",
+            &[JValueGen::Object(&provider)],
+        ) {
+            Ok(value) => value.l().unwrap_or_else(|_| JObject::null()),
+            Err(error) => {
+                let _ = map_android_error(env, error);
+                continue;
+            }
+        };
+
+        if !location.as_raw().is_null() {
+            return env
+                .new_global_ref(&location)
+                .map(Some)
+                .map_err(|e| map_android_error(env, e));
+        }
+    }
+
+    Ok(None)
+}
+
 fn get_location_manager<'a>(env: &mut JNIEnv<'a>, context: &JObject<'_>) -> Result<JObject<'a>> {
-    let service_name = env.new_string("location")?;
+    let service_name = env
+        .new_string("location")
+        .map_err(|e| map_android_error(env, e))?;
 
     env.call_method(
         context,
         "getSystemService",
         "(Ljava/lang/String;)Ljava/lang/Object;",
         &[JValueGen::Object(&service_name)],
-    )?
+    )
+    .map_err(|e| map_android_error(env, e))?
     .l()
     .map_err(|e| e.into())
 }
 
-fn get_executor<'a>(env: &mut JNIEnv<'a>, context: &JObject<'_>) -> Result<JObject<'a>> {
-    env.call_method(
-        context,
-        "getMainExecutor",
-        "()Ljava/util/concurrent/Executor;",
-        &[],
-    )?
-    .l()
-    .map_err(|e| e.into())
+fn permission_array<'a>(env: &mut JNIEnv<'a>, permissions: &[&str]) -> Result<JObject<'a>> {
+    let first_permission = env
+        .new_string(permissions[0])
+        .map_err(|e| map_android_error(env, e))?;
+    let array = env
+        .new_object_array(permissions.len() as i32, "java/lang/String", &first_permission)
+        .map_err(|e| map_android_error(env, e))?;
+
+    for (index, permission) in permissions.iter().enumerate().skip(1) {
+        let permission = env
+            .new_string(*permission)
+            .map_err(|e| map_android_error(env, e))?;
+        env.set_object_array_element(&array, index as i32, &permission)
+            .map_err(|e| map_android_error(env, e))?;
+    }
+
+    Ok(array.into())
+}
+
+fn launch_permission_fragment(
+    env: &mut JNIEnv<'_>,
+    activity: &JObject<'_>,
+    ptr: jlong,
+    permissions: &JObject<'_>,
+) -> Result<()> {
+    let fragment_class = callback::get_permission_fragment_class(env)?;
+
+    env.call_static_method(
+        fragment_class,
+        "show",
+        "(Landroid/app/Activity;J[Ljava/lang/String;)V",
+        &[
+            JValueGen::Object(activity),
+            JValueGen::Long(ptr),
+            JValueGen::Object(permissions),
+        ],
+    )
+    .map_err(|e| map_android_error(env, e))?;
+    Ok(())
+}
+
+fn remove_permission_fragment(env: &mut JNIEnv<'_>, activity: &JObject<'_>) -> Result<()> {
+    let fragment_class = callback::get_permission_fragment_class(env)?;
+    env.call_static_method(
+        fragment_class,
+        "removeExisting",
+        "(Landroid/app/Activity;)V",
+        &[JValueGen::Object(activity)],
+    )
+    .map_err(|e| map_android_error(env, e))?;
+    Ok(())
+}
+
+fn has_location_permission(env: &mut JNIEnv<'_>, context: &JObject<'_>) -> Result<bool> {
+    if has_permission(env, context, COARSE_LOCATION_PERMISSION)? {
+        return Ok(true);
+    }
+
+    has_permission(env, context, FINE_LOCATION_PERMISSION)
+}
+
+fn has_permission(env: &mut JNIEnv<'_>, context: &JObject<'_>, permission: &str) -> Result<bool> {
+    let permission = env
+        .new_string(permission)
+        .map_err(|e| map_android_error(env, e))?;
+    let result = env
+        .call_method(
+            context,
+            "checkSelfPermission",
+            "(Ljava/lang/String;)I",
+            &[JValueGen::Object(&permission)],
+        )
+        .map_err(|e| map_android_error(env, e))?
+        .i()?;
+
+    Ok(result == PERMISSION_GRANTED)
+}
+
+/// Turns a JNI error into our [`Error`], clearing any pending Java exception first — a leftover
+/// exception would blow up the next JNI call (that was the original crash in this crate).
+fn map_android_error(env: &mut JNIEnv<'_>, error: JniError) -> Error {
+    match error {
+        JniError::JavaException => {
+            let throwable = env.exception_occurred().ok();
+            let _ = env.exception_clear();
+
+            if throwable
+                .as_ref()
+                .filter(|throwable| !throwable.as_raw().is_null())
+                .and_then(|throwable| {
+                    env.is_instance_of(throwable, "java/lang/SecurityException").ok()
+                })
+                .unwrap_or(false)
+            {
+                Error::AuthorizationDenied
+            } else {
+                Error::Unknown
+            }
+        }
+        _ => error.into(),
+    }
 }
 
 fn construct_callback<'a>(
     env: &mut JNIEnv<'a>,
-    handler_ptr: *const InnerHandler,
+    shared_ptr: *const Shared,
 ) -> Result<JObject<'a>> {
     let callback_class = callback::get_callback_class(env)?;
 
-    // TODO: Is there a better way without the provenance API?
-    let transmuted: [i64; 2] = unsafe { std::mem::transmute(handler_ptr) };
+    // `Shared` is `Sized`, so `*const Shared` is a thin pointer that fits in one `jlong`.
     env.new_object(
         callback_class,
-        "(JJ)V",
-        &[
-            JValueGen::Long(transmuted[0]),
-            JValueGen::Long(transmuted[1]),
-        ],
-    )
-    .map_err(|e| e.into())
-}
-
-fn construct_location_request<'a>(env: &mut JNIEnv<'a>) -> Result<JObject<'a>> {
-    let builder = env.new_object(
-        "android/location/LocationRequest$Builder",
         "(J)V",
-        // TODO: Don't hardcode
-        // TODO: Could use:
-        // https://developer.android.com/reference/android/location/LocationRequest#PASSIVE_INTERVAL
-        // but then we have to determine a minupdateinterval.
-        &[JValueGen::Long(1000)],
-    )?;
-
-    env.call_method(
-        builder,
-        "build",
-        "()Landroid/location/LocationRequest;",
-        &[],
-    )?
-    .l()
-    .map_err(|e| e.into())
+        &[JValueGen::Long(shared_ptr as jlong)],
+    )
+    .map_err(|e| map_android_error(env, e))
 }
 
 // TODO: Could inner be JObject<'a>?
@@ -249,10 +545,12 @@ impl Location<'_> {
     pub fn coordinates(&self) -> Result<Coordinates> {
         robius_android_env::with_activity(|env, _| {
             let latitude = env
-                .call_method(&self.inner, "getLatitude", "()D", &[])?
+                .call_method(&self.inner, "getLatitude", "()D", &[])
+                .map_err(|e| map_android_error(env, e))?
                 .d()?;
             let longitude = env
-                .call_method(&self.inner, "getLongitude", "()D", &[])?
+                .call_method(&self.inner, "getLongitude", "()D", &[])
+                .map_err(|e| map_android_error(env, e))?
                 .d()?;
             Ok(Coordinates {
                 latitude,
@@ -266,7 +564,8 @@ impl Location<'_> {
 
     pub fn altitude(&self) -> Result<f64> {
         robius_android_env::with_activity(|env, _| {
-            env.call_method(&self.inner, "getAltitude", "()D", &[])?
+            env.call_method(&self.inner, "getAltitude", "()D", &[])
+                .map_err(|e| map_android_error(env, e))?
                 .d()
                 .map_err(|e| e.into())
         })
@@ -276,10 +575,11 @@ impl Location<'_> {
 
     pub fn bearing(&self) -> Result<f64> {
         robius_android_env::with_activity(|env, _| {
-            match env.call_method(&self.inner, "getBearing", "()F", &[])?.f() {
-                Ok(bearing) => Ok(bearing as f64),
-                Err(e) => Err(e.into()),
-            }
+            let bearing = env
+                .call_method(&self.inner, "getBearing", "()F", &[])
+                .map_err(|e| map_android_error(env, e))?
+                .f()?;
+            Ok(bearing as f64)
         })
         .map_err(|_| Error::AndroidEnvironment)
         .and_then(|x| x)
@@ -287,10 +587,11 @@ impl Location<'_> {
 
     pub fn speed(&self) -> Result<f64> {
         robius_android_env::with_activity(|env, _| {
-            match env.call_method(&self.inner, "getSpeed", "()F", &[])?.f() {
-                Ok(speed) => Ok(speed as f64),
-                Err(e) => Err(e.into()),
-            }
+            let speed = env
+                .call_method(&self.inner, "getSpeed", "()F", &[])
+                .map_err(|e| map_android_error(env, e))?
+                .f()?;
+            Ok(speed as f64)
         })
         .map_err(|_| Error::AndroidEnvironment)
         .and_then(|x| x)
@@ -298,14 +599,15 @@ impl Location<'_> {
 
     pub fn time(&self) -> Result<SystemTime> {
         robius_android_env::with_activity(|env, _| {
-            match env.call_method(&self.inner, "getTime", "()J", &[])?.f() {
-                Ok(time) => Ok(time as f64),
-                Err(e) => Err(e.into()),
-            }
+            // `Location.getTime()` returns milliseconds since the Unix epoch, as a `long`.
+            let millis = env
+                .call_method(&self.inner, "getTime", "()J", &[])
+                .map_err(|e| map_android_error(env, e))?
+                .j()?;
+            Ok(SystemTime::UNIX_EPOCH + Duration::from_millis(millis as u64))
         })
         .map_err(|_| Error::AndroidEnvironment)
         .and_then(|x| x)
-        .map(|secs| SystemTime::UNIX_EPOCH + Duration::from_secs_f64(secs))
     }
 }
 

--- a/crates/location/src/sys/apple/delegate.rs
+++ b/crates/location/src/sys/apple/delegate.rs
@@ -1,7 +1,11 @@
+use std::cell::Cell;
+
 use objc2::{
     define_class, msg_send, rc::Retained, DeclaredClass, MainThreadMarker, MainThreadOnly,
 };
-use objc2_core_location::{CLError, CLLocation, CLLocationManager, CLLocationManagerDelegate};
+use objc2_core_location::{
+    CLAuthorizationStatus, CLError, CLLocation, CLLocationManager, CLLocationManagerDelegate,
+};
 use objc2_foundation::{NSArray, NSError, NSObject, NSObjectProtocol};
 
 use super::Location;
@@ -9,8 +13,21 @@ use crate::{Error, Handler};
 
 type InnerHandler = dyn Handler;
 
+/// Location requests we're holding until permission is granted. `requestLocation` just fails if
+/// called before that, so we replay it from `didChangeAuthorization` once we're allowed.
+#[derive(Clone, Copy, Default)]
+struct Pending {
+    update_once: bool,
+    start_updates: bool,
+}
+
 pub(super) struct Ivars {
     handler: Box<InnerHandler>,
+    // Only ever touched on the main thread (the delegate is `MainThreadOnly`).
+    pending: Cell<Pending>,
+    // While `one_shot`, deliver only fixes newer than `last_delivered` (never go backwards).
+    one_shot: Cell<bool>,
+    last_delivered: Cell<f64>,
 }
 
 define_class!(
@@ -30,20 +47,23 @@ define_class!(
             locations: &NSArray<CLLocation>,
         ) {
             // Note: `.iter()` here requires objc2-foundation's `NSEnumerator` feature.
+            let one_shot = self.ivars().one_shot.get();
             for location in locations.iter() {
-                self.ivars().handler.handle(
-                    crate::Location {
-                        inner: Location {
-                            inner: &location,
-                        },
-                    }
-                );
+                if one_shot {
+                    self.deliver_if_newer(&location);
+                } else {
+                    self.deliver(&location); // continuous updates: just pass every fix along
+                }
             }
         }
 
         #[unsafe(method(locationManager:didFailWithError:))]
         #[allow(non_snake_case)]
         unsafe fn locationManager_didFailWithError(&self, _: &CLLocationManager, error: &NSError) {
+            // In a one-shot that already delivered a cached fix, don't overwrite it with an error.
+            if self.ivars().one_shot.get() && self.ivars().last_delivered.get().is_finite() {
+                return;
+            }
             self.ivars().handler.error(match CLError(error.code()) {
                 // kCLErrorLocationUnknown
                 CLError::LocationUnknown => Error::TemporarilyUnavailable,
@@ -54,9 +74,16 @@ define_class!(
                 _ => Error::Unknown,
             })
         }
+
+        // Fires with the initial state and on every change; replays a deferred request once granted.
+        #[unsafe(method(locationManagerDidChangeAuthorization:))]
+        #[allow(non_snake_case)]
+        unsafe fn locationManagerDidChangeAuthorization(&self, manager: &CLLocationManager) {
+            let status = unsafe { manager.authorizationStatus() };
+            self.authorization_changed(manager, status);
+        }
     }
 );
-
 
 impl RobiusLocationDelegate {
     /// Allocates a new `RobiusLocationDelegate` and initializes it with the given handler
@@ -65,7 +92,86 @@ impl RobiusLocationDelegate {
         let this = Self::alloc(mtm)
             .set_ivars(Ivars {
                 handler: Box::new(handler),
+                pending: Cell::new(Pending::default()),
+                one_shot: Cell::new(false),
+                last_delivered: Cell::new(f64::NEG_INFINITY),
             });
         unsafe { msg_send![super(this), init] }
+    }
+
+    fn deliver(&self, location: &CLLocation) {
+        self.ivars().handler.handle(crate::Location { inner: Location { inner: location } });
+    }
+
+    /// Delivers only if newer than the last fix this one-shot, so it never jumps backwards.
+    fn deliver_if_newer(&self, location: &CLLocation) {
+        let ts = unsafe { location.timestamp().timeIntervalSince1970() };
+        if ts <= self.ivars().last_delivered.get() {
+            return;
+        }
+        self.ivars().last_delivered.set(ts);
+        self.deliver(location);
+    }
+
+    /// Begins a one-shot: resets the guard and delivers the cached fix first, before `requestLocation` refines.
+    pub(super) fn begin_one_shot(&self, manager: &CLLocationManager) {
+        self.ivars().last_delivered.set(f64::NEG_INFINITY);
+        self.ivars().one_shot.set(true);
+        if let Some(location) = unsafe { manager.location() } {
+            self.deliver_if_newer(&location);
+        }
+    }
+
+    /// Start continuous updates; from here we just pass every fix along.
+    pub(super) fn begin_continuous(&self) {
+        self.ivars().one_shot.set(false);
+    }
+
+    /// Holds a one-shot request until permission is granted.
+    pub(super) fn defer_update_once(&self) {
+        let mut pending = self.ivars().pending.get();
+        pending.update_once = true;
+        self.ivars().pending.set(pending);
+    }
+
+    /// Holds off on continuous updates until permission is granted.
+    pub(super) fn defer_start_updates(&self) {
+        let mut pending = self.ivars().pending.get();
+        pending.start_updates = true;
+        self.ivars().pending.set(pending);
+    }
+
+    /// Cancels a held `start_updates`, so granting later won't start updates (a held one-shot stays).
+    pub(super) fn cancel_deferred_start_updates(&self) {
+        let mut pending = self.ivars().pending.get();
+        pending.start_updates = false;
+        self.ivars().pending.set(pending);
+    }
+
+    fn authorization_changed(&self, manager: &CLLocationManager, status: CLAuthorizationStatus) {
+        match status {
+            CLAuthorizationStatus::AuthorizedWhenInUse | CLAuthorizationStatus::AuthorizedAlways => {
+                let pending = self.ivars().pending.replace(Pending::default());
+                // Run the one-shot first, so a held `start_updates` leaves us in continuous mode.
+                if pending.update_once {
+                    self.begin_one_shot(manager);
+                    unsafe { manager.requestLocation() };
+                }
+                if pending.start_updates {
+                    self.begin_continuous();
+                    unsafe { manager.startUpdatingLocation() };
+                }
+            }
+            CLAuthorizationStatus::Denied | CLAuthorizationStatus::Restricted => {
+                // Only report a denial if a request was pending, else the initial callback would
+                // fire a spurious error.
+                let pending = self.ivars().pending.replace(Pending::default());
+                if pending.update_once || pending.start_updates {
+                    self.ivars().handler.error(Error::AuthorizationDenied);
+                }
+            }
+            // `NotDetermined` (or any future state): keep waiting, leave any pending request queued.
+            _ => {}
+        }
     }
 }

--- a/crates/location/src/sys/apple/mod.rs
+++ b/crates/location/src/sys/apple/mod.rs
@@ -5,15 +5,16 @@ use std::time::{Duration, SystemTime};
 use delegate::RobiusLocationDelegate as Delegate;
 use objc2::{rc::Retained, runtime::ProtocolObject};
 use objc2_core_location::{
-    CLLocation, CLLocationCoordinate2D, CLLocationManager, CLLocationManagerDelegate,
+    kCLLocationAccuracyBest, kCLLocationAccuracyKilometer, CLAuthorizationStatus, CLLocation,
+    CLLocationCoordinate2D, CLLocationManager, CLLocationManagerDelegate,
 };
 
 use crate::{Access, Accuracy, Coordinates, Handler, Result};
 
 pub(crate) struct Manager {
     inner: Retained<CLLocationManager>,
-    // We must not to drop the Delegate/handler until the manager itself is dropped.
-    _delegate: Retained<ProtocolObject<dyn CLLocationManagerDelegate>>,
+    // Held for the manager's lifetime, and kept as the concrete type so we can queue up held requests.
+    delegate: Retained<Delegate>,
 }
 
 impl Manager {
@@ -26,15 +27,22 @@ impl Manager {
         let mtm = objc2::MainThreadMarker::new()
             .ok_or(crate::Error::NotMainThread)?;
         let inner = unsafe { CLLocationManager::new() };
-        let delegate = ProtocolObject::from_retained(Delegate::new(mtm, handler));
-        unsafe { inner.setDelegate(Some(&delegate)) };
-        Ok(Self {
-            inner,
-            _delegate: delegate,
-        })
+        let delegate = Delegate::new(mtm, handler);
+        let protocol: &ProtocolObject<dyn CLLocationManagerDelegate> =
+            ProtocolObject::from_ref(&*delegate);
+        unsafe { inner.setDelegate(Some(protocol)) };
+        Ok(Self { inner, delegate })
     }
 
-    pub(crate) fn request_authorization(&self, access: Access, _: Accuracy) -> Result<()> {
+    pub(crate) fn request_authorization(&self, access: Access, accuracy: Accuracy) -> Result<()> {
+        // Hint the desired precision; `kCLLocationAccuracyKilometer` matches an approximate request.
+        let desired = unsafe {
+            match accuracy {
+                Accuracy::Precise => kCLLocationAccuracyBest,
+                Accuracy::Approximate => kCLLocationAccuracyKilometer,
+            }
+        };
+        unsafe { self.inner.setDesiredAccuracy(desired) };
         match access {
             Access::Foreground => unsafe { self.inner.requestWhenInUseAuthorization(); },
             Access::Background => unsafe { self.inner.requestAlwaysAuthorization(); },
@@ -43,16 +51,31 @@ impl Manager {
     }
 
     pub(crate) fn update_once(&self) -> Result<()> {
-        unsafe { self.inner.requestLocation(); }
+        // `requestLocation` fails (rather than waiting) if called before authorization is granted,
+        // so while the status is undetermined we defer it until `didChangeAuthorization` fires.
+        match unsafe { self.inner.authorizationStatus() } {
+            CLAuthorizationStatus::NotDetermined => self.delegate.defer_update_once(),
+            _ => {
+                self.delegate.begin_one_shot(&self.inner); // deliver the cached fix first, then refine
+                unsafe { self.inner.requestLocation() };
+            }
+        }
         Ok(())
     }
 
     pub(crate) fn start_updates(&self) -> Result<()> {
-        unsafe { self.inner.startUpdatingLocation(); }
+        match unsafe { self.inner.authorizationStatus() } {
+            CLAuthorizationStatus::NotDetermined => self.delegate.defer_start_updates(),
+            _ => {
+                self.delegate.begin_continuous();
+                unsafe { self.inner.startUpdatingLocation() };
+            }
+        }
         Ok(())
     }
 
     pub(crate) fn stop_updates(&self) -> Result<()> {
+        self.delegate.cancel_deferred_start_updates();
         unsafe { self.inner.stopUpdatingLocation(); }
         Ok(())
     }

--- a/crates/location/src/sys/unsupported.rs
+++ b/crates/location/src/sys/unsupported.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
+use std::time::SystemTime;
 
-use crate::{Access, Accuracy, Coordinates, Handler, Result};
+use crate::{Access, Accuracy, Coordinates, Error, Handler, Result};
 
 pub(crate) struct Manager;
 

--- a/crates/location/src/sys/windows.rs
+++ b/crates/location/src/sys/windows.rs
@@ -6,19 +6,24 @@ use std::{
 
 use windows::{
     Devices::Geolocation::{
-        Geocoordinate, GeolocationAccessStatus, Geolocator, PositionStatus, StatusChangedEventArgs,
+        Geocoordinate, GeolocationAccessStatus, Geolocator, PositionAccuracy,
+        PositionChangedEventArgs, PositionStatus, StatusChangedEventArgs,
     },
-    Foundation::{EventRegistrationToken, TypedEventHandler},
+    Foundation::{EventRegistrationToken, TimeSpan, TypedEventHandler},
 };
 
 use crate::{Access, Accuracy, Coordinates, Error, Handler, Result};
 
 pub(crate) struct Manager {
     inner: Arc<Geolocator>,
-    handler: TypedEventHandler<Geolocator, StatusChangedEventArgs>,
+    // Delivers status transitions and errors.
+    status_handler: TypedEventHandler<Geolocator, StatusChangedEventArgs>,
+    // Delivers continuous position updates (`StatusChanged` alone never streams positions).
+    position_handler: TypedEventHandler<Geolocator, PositionChangedEventArgs>,
     // NOTE: Technically the Mutex isn't necessary, but removing it requires some finnicky unsafe.
     rust_handler: Arc<Mutex<dyn Handler>>,
-    token: Option<EventRegistrationToken>,
+    status_token: Option<EventRegistrationToken>,
+    position_token: Option<EventRegistrationToken>,
 }
 
 impl Manager {
@@ -30,22 +35,15 @@ impl Manager {
         let rust_handler = Arc::new(Mutex::new(handler));
         let rust_handler_cloned = rust_handler.clone();
 
-        let event_handler: TypedEventHandler<Geolocator, StatusChangedEventArgs> =
+        let status_handler: TypedEventHandler<Geolocator, StatusChangedEventArgs> =
             TypedEventHandler::new(
-                move |geolocator: &Option<Geolocator>, status: &Option<StatusChangedEventArgs>| {
+                move |_geolocator: &Option<Geolocator>, status: &Option<StatusChangedEventArgs>| {
                     if let Ok(handler) = rust_handler_cloned.lock() {
                         match status.as_ref() {
                             Some(status) => match status.Status() {
                                 Ok(status) => match status {
-                                    PositionStatus::Ready => {
-                                        if let Some(geolocator) = geolocator.as_ref() {
-                                            if let Ok(location) = get_location(geolocator) {
-                                                handler.handle(location)
-                                            }
-                                        } else {
-                                            handler.error(Error::Unknown);
-                                        }
-                                    }
+                                    // `position_handler` owns location delivery; this only reports status.
+                                    PositionStatus::Ready => {}
                                     PositionStatus::Initializing => {}
                                     PositionStatus::NoData => {
                                         handler.error(Error::TemporarilyUnavailable)
@@ -69,15 +67,46 @@ impl Manager {
                 },
             );
 
+        let rust_handler_position = rust_handler.clone();
+        let position_handler: TypedEventHandler<Geolocator, PositionChangedEventArgs> =
+            TypedEventHandler::new(
+                move |_geolocator: &Option<Geolocator>, args: &Option<PositionChangedEventArgs>| {
+                    if let Ok(handler) = rust_handler_position.lock() {
+                        if let Some(coordinate) = args
+                            .as_ref()
+                            .and_then(|args| args.Position().ok())
+                            .and_then(|position| position.Coordinate().ok())
+                        {
+                            handler.handle(crate::Location {
+                                inner: Location {
+                                    inner: coordinate,
+                                    _phantom_data: PhantomData,
+                                },
+                            });
+                        }
+                    }
+
+                    Ok(())
+                },
+            );
+
         Ok(Self {
             inner: geolocator,
-            handler: event_handler,
+            status_handler,
+            position_handler,
             rust_handler,
-            token: None,
+            status_token: None,
+            position_token: None,
         })
     }
 
-    pub fn request_authorization(&self, _access: Access, _accuracy: Accuracy) -> Result<()> {
+    pub fn request_authorization(&self, _access: Access, accuracy: Accuracy) -> Result<()> {
+        // Hint the desired precision (best-effort): `High` for precise, `Default` for approximate.
+        let desired = match accuracy {
+            Accuracy::Precise => PositionAccuracy::High,
+            Accuracy::Approximate => PositionAccuracy::Default,
+        };
+        let _ = self.inner.SetDesiredAccuracy(desired);
         match Geolocator::RequestAccessAsync()?.get()? {
             GeolocationAccessStatus::Allowed => Ok(()),
             GeolocationAccessStatus::Denied => Err(Error::AuthorizationDenied),
@@ -97,8 +126,14 @@ impl Manager {
 
         spawn(move || {
             if let Ok(handler) = handler.lock() {
-                if let Ok(location) = get_location(inner_cloned.as_ref()) {
-                    handler.handle(location)
+                // Cached-first, then refine; error only if nothing was delivered (never hang).
+                let delivered_cached = match get_cached_location(inner_cloned.as_ref()) {
+                    Ok(location) => { handler.handle(location); true }
+                    Err(_) => false,
+                };
+                match get_location(inner_cloned.as_ref()) {
+                    Ok(location) => handler.handle(location),
+                    Err(e) => if !delivered_cached { handler.error(e); }
                 }
             }
         });
@@ -107,13 +142,21 @@ impl Manager {
     }
 
     pub fn start_updates(&mut self) -> Result<()> {
-        let token = self.inner.StatusChanged(&self.handler)?;
-        self.token = Some(token);
+        self.stop_updates()?; // idempotent: drop any earlier registrations first
+
+        // Hint the provider to stream positions (else PositionChanged may fire once); may fail.
+        let _ = self.inner.SetReportInterval(1000);
+
+        self.position_token = Some(self.inner.PositionChanged(&self.position_handler)?);
+        self.status_token = Some(self.inner.StatusChanged(&self.status_handler)?);
         Ok(())
     }
 
     pub fn stop_updates(&mut self) -> Result<()> {
-        if let Some(token) = self.token.take() {
+        if let Some(token) = self.position_token.take() {
+            self.inner.RemovePositionChanged(token)?;
+        }
+        if let Some(token) = self.status_token.take() {
             self.inner.RemoveStatusChanged(token)?;
         }
         Ok(())
@@ -166,10 +209,25 @@ impl Location<'_> {
     }
 }
 
-fn get_location(geolocator: &Geolocator) -> Result<crate::Location> {
+fn get_location(geolocator: &Geolocator) -> Result<crate::Location<'_>> {
     Ok(crate::Location {
         inner: Location {
             inner: geolocator.GetGeopositionAsync()?.get()?.Coordinate()?,
+            _phantom_data: PhantomData,
+        },
+    })
+}
+
+// A recently-cached fix, returned near-instantly (short timeout = don't acquire a new one).
+fn get_cached_location(geolocator: &Geolocator) -> Result<crate::Location<'_>> {
+    let max_age = TimeSpan { Duration: 3600 * 10_000_000 }; // accept a fix up to ~1h old
+    let timeout = TimeSpan { Duration: 1_000_000 };         // 100ms: return cached, don't acquire anew
+    Ok(crate::Location {
+        inner: Location {
+            inner: geolocator
+                .GetGeopositionAsyncWithAgeAndTimeout(max_age, timeout)?
+                .get()?
+                .Coordinate()?,
             _phantom_data: PhantomData,
         },
     })


### PR DESCRIPTION
Fixes issue #2 by using a fragment to do all the hard stuff. Fully support all permissions behavior (all the time, one time, denied, etc) and always respond correctly to every case.

A regular "get location once" request was also too slow, now it's instant by returning the latest cached location value and then refining it later with an updated location value once that's ready from the system. This was particularly bad on Android when the user only granted coarse/approximate location permissions.

Also, ensure that Android is supported on ALL API levels, even down to API level 1. 

Apply the same behavior to the iOS and Windows backends.