### PR TITLE
authentication: general improvements and platform fixes

### DIFF
--- a/crates/authentication/Cargo.toml
+++ b/crates/authentication/Cargo.toml
@@ -65,6 +65,7 @@ windows = { workspace = true, features = [
     # WinRT
     "Win32_UI_WindowsAndMessaging",
     "Win32_System_WinRT",
+    "Win32_System_Com",
     # Fallback
     "Win32_Foundation",
     "Win32_Graphics_Gdi",

--- a/crates/authentication/README.md
+++ b/crates/authentication/README.md
@@ -11,6 +11,7 @@ This crate supports:
   * Requires the `NSFaceIDUsageDescription` key in your app's `Info.plist` file.
 * Android: Biometric prompt and regular screen lock. See below for additional steps.
   * Requires the `USE_BIOMETRIC` permission in your app's manifest.
+  * Requires API level 28 (Android 9) for biometrics, or API level 29 (Android 10) for the password / device-credential fallback.
 * Windows: Windows Hello (face recognition, fingerprint, PIN),
 plus winrt-based fallback for username/password.
 * Linux: [`polkit`]-based authentication using the desktop environment's prompt.
@@ -29,6 +30,11 @@ To use this crate on Android, you must add the following to your app's `AndroidM
 ```xml
 <uses-permission android:name="android.permission.USE_BIOMETRIC" />
 ```
+
+### Minimum API level
+This crate uses `android.hardware.biometrics.BiometricPrompt`, so the minimum supported API level is **28 (Android 9)**.
+The password / device-credential fallback requires API level **29 (Android 10)**; requesting a credential-only policy on a lower
+level returns `Error::Unavailable`. Set `minSdk` accordingly in your app.
 
 ## Usage on Linux
 

--- a/crates/authentication/build.rs
+++ b/crates/authentication/build.rs
@@ -6,6 +6,9 @@ fn main() {
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
 
     if target_os == "android" {
+        // android-build already emits rerun-if-env-changed for the SDK/JDK env
+        // vars it reads (ANDROID_HOME, ANDROID_PLATFORM, JAVA_HOME, etc.), so we
+        // only track the Java source here.
         println!("cargo:rerun-if-changed={JAVA_FILE_RELATIVE_PATH}");
 
         let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());

--- a/crates/authentication/examples/simple_authentication.rs
+++ b/crates/authentication/examples/simple_authentication.rs
@@ -43,7 +43,10 @@ const TEXT: Text = Text {
         description: None,
     },
     apple: "authenticate",
-    windows: WindowsText::new("Title", "Description").unwrap(),
+    windows: match WindowsText::new("Title", "Description") {
+        Some(text) => text,
+        None => panic!("Windows text too long"),
+    },
 };
 
 fn main() {

--- a/crates/authentication/src/error.rs
+++ b/crates/authentication/src/error.rs
@@ -21,6 +21,13 @@ pub enum Error {
     UserCanceled,
     /// The provided action ID is not in the policy's allowed list.
     InvalidActionId,
+    /// The prompt text is invalid for this platform — e.g. an empty
+    /// [`Text::apple`] reason or an empty [`AndroidText::title`], which the
+    /// platform APIs reject.
+    ///
+    /// [`Text::apple`]: crate::Text::apple
+    /// [`AndroidText::title`]: crate::AndroidText::title
+    InvalidText,
 
     // Apple-specific errors
     /// The app canceled authentication.
@@ -130,6 +137,55 @@ pub enum Error {
 
     /// An unknown error occurred.
     Unknown,
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let description = match self {
+            #[cfg(target_os = "android")]
+            Self::Java(e) => return write!(f, "Java error during authentication: {e}"),
+            Self::Authentication => "the user failed to provide valid credentials",
+            Self::Exhausted => "authentication failed due to too many failed attempts",
+            Self::Unavailable => "the requested authentication method was unavailable",
+            Self::UserCanceled => "the user canceled authentication",
+            Self::InvalidActionId => "the provided action ID is not in the policy's allowed list",
+            Self::InvalidText => "the provided prompt text is invalid for the current platform",
+            Self::AppCanceled => "the app canceled authentication",
+            Self::SystemCanceled => "the system canceled authentication",
+            Self::BiometryDisconnected => {
+                "the paired biometric accessory required for authentication is not connected"
+            }
+            Self::NotPaired => "no biometric accessory required for authentication is paired",
+            Self::NotEnrolled => "the user has no enrolled biometric identities",
+            Self::NotInteractive => "displaying the required authentication UI is forbidden",
+            Self::CompanionNotAvailable => {
+                "authentication with a companion device (e.g., Apple Watch) failed"
+            }
+            Self::InvalidDimensions => "the authentication input has invalid dimensions",
+            Self::PasscodeNotSet => "no passcode is set on the device",
+            Self::UserFallback => {
+                "the user chose the fallback authentication method, \
+                 but the policy does not support fallback"
+            }
+            Self::UpdateRequired => "a security update is required before authenticating",
+            Self::Timeout => "authentication timed out",
+            Self::Busy => "the biometric verifier device is busy",
+            Self::DisabledByPolicy => "group policy has disabled the biometric verifier device",
+            Self::NotConfigured => "no biometric verifier device is configured for this user",
+            Self::Unknown => "an unknown authentication error occurred",
+        };
+        f.write_str(description)
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        #[cfg(target_os = "android")]
+        if let Self::Java(e) = self {
+            return Some(&**e);
+        }
+        None
+    }
 }
 
 #[cfg(target_os = "android")]

--- a/crates/authentication/src/lib.rs
+++ b/crates/authentication/src/lib.rs
@@ -4,8 +4,10 @@
 //! - Apple: TouchID, FaceID, and regular username/password on macOS and iOS.
 //! - Android: See below for additional steps.
 //!   - Requires the `USE_BIOMETRIC` permission in your app's manifest.
-//! - Windows: Windows Hello (face recognition, fingerprint, PIN), plus
-//!   winrt-based fallback for username/password.
+//!   - Requires API level 28 (Android 9) for biometrics, or API level 29
+//!     (Android 10) if you use the password / device-credential fallback.
+//! - Windows: Windows Hello (face recognition, fingerprint, PIN) via WinRT, plus
+//!   a Win32 credential-UI fallback for username/password.
 //! - Linux: [`polkit`]-based authentication using the desktop environment's
 //!   prompt.
 //!   - **Note: Linux support is currently incomplete.**
@@ -21,6 +23,8 @@
 //!     .biometrics(Some(BiometricStrength::Strong))
 //!     .password(true)
 //!     .companion(true)
+//!     // Required on Linux (polkit action IDs); a no-op on other platforms.
+//!     .action_ids(["org.robius.authentication"])
 //!     .build()
 //!     .unwrap();
 //!
@@ -43,13 +47,11 @@
 //!
 //! Context::new(())
 //!     .authenticate(text, &policy, callback)
-//!     .expect("authentication failed");
+//!     .expect("failed to display the authentication prompt");
 //! ```
 //!
 //! The `Text` struct can also be constructed at compile-time to avoid run-time unwraps:
 //! ```
-//! #![feature(const_option)]
-//!
 //! use robius_authentication::{AndroidText, Text, WindowsText};
 //!
 //! const TEXT: Text = Text {
@@ -59,7 +61,10 @@
 //!         description: None,
 //!     },
 //!     apple: "authenticate",
-//!     windows: WindowsText::new("Title", "Description").unwrap(),
+//!     windows: match WindowsText::new("Title", "Description") {
+//!         Some(text) => text,
+//!         None => panic!("Windows text too long"),
+//!     },
 //! };
 //! ```
 //!
@@ -73,6 +78,14 @@
 //! ```xml
 //! <uses-permission android:name="android.permission.USE_BIOMETRIC" />
 //! ```
+//!
+//! ### Minimum API level
+//!
+//! This crate uses `android.hardware.biometrics.BiometricPrompt`, so the minimum
+//! supported API level is 28 (Android 9). The password / device-credential
+//! fallback needs API level 29 (Android 10); requesting a credential-only policy
+//! on a lower level returns [`Error::Unavailable`]. Set `minSdk` accordingly in
+//! your app.
 //!
 //! [`polkit`]: https://www.freedesktop.org/software/polkit/docs/latest/polkit.8.html
 
@@ -124,13 +137,16 @@ impl Context {
     ///
     /// Note that the returned `Result` does not indicate whether
     /// authentication was successful. This function returns `Ok(())`
-    /// to indicate that the authentication prompt was successfully displayed,
-    /// not that the user successfully authenticated.
+    /// to indicate that the authentication request was successfully initiated
+    /// (i.e., the prompt was or will be shown), not that the user successfully
+    /// authenticated. On some platforms (Android, Linux, Windows) the prompt is
+    /// shown asynchronously after this function has already returned.
     ///
     /// For that purpose, the given `callback` will be called
     /// with a Result indicating whether authentication succeeded.
-    /// Note that the callback may be not be called at all,
-    /// but will always be called upon success.
+    /// If this function returns an error, the callback may never be invoked;
+    /// if it returns `Ok(())`, the callback will eventually be invoked
+    /// with the result of the authentication attempt.
     ///
     /// On Linux: `message` is unused because polkit looks up the prompt text from the
     /// action definition in the installed `.policy` file (its `<message>`/`<description>`).
@@ -278,10 +294,7 @@ impl PolicyBuilder {
     #[must_use]
     pub fn build(self) -> Option<Policy> {
         Some(Policy {
-            inner: match self.inner.build() {
-                Some(inner) => inner,
-                None => return None,
-            },
+            inner: self.inner.build()?,
         })
     }
 }

--- a/crates/authentication/src/sys/android/AuthenticationCallback.java
+++ b/crates/authentication/src/sys/android/AuthenticationCallback.java
@@ -2,32 +2,47 @@
 
 package robius.authentication;
 
+import android.content.DialogInterface;
 import android.hardware.biometrics.BiometricPrompt;
 
-public class AuthenticationCallback extends BiometricPrompt.AuthenticationCallback {
+public class AuthenticationCallback extends BiometricPrompt.AuthenticationCallback
+    implements DialogInterface.OnClickListener {
   private long pointer;
 
-  /* TODO: There are neater ways of doing this */
-  private native void rustCallback(long pointer, int errorCode, int helpCode);
+  private native void rustCallback(long pointer, int errorCode);
 
   public AuthenticationCallback(long pointer) {
     this.pointer = pointer;
   }
 
-  public void onAuthenticationError(int errorCode, CharSequence errString) {
-    rustCallback(pointer, errorCode, 0);
+  /* Invokes the Rust callback at most once; the Rust side frees `pointer` when invoked,
+   * so calling it a second time would be a use-after-free. */
+  private synchronized void invokeOnce(int errorCode) {
+    if (pointer != 0) {
+      rustCallback(pointer, errorCode);
+      pointer = 0;
+    }
   }
 
-  /* This is called when the user presents an incorrect authenticator (e.g. fingerprint or password). However, the
-   * prompt remains displayed and so we don't really care, until the prompt dissapears, in which case
-   * `onAuthenticationError`, `onAuthenticationHelp`, or `onAuthenticationSucceeded` is called. */
+  public void onAuthenticationError(int errorCode, CharSequence errString) {
+    invokeOnce(errorCode);
+  }
+
+  /* Called when the user presents an invalid credential (e.g., an unrecognized fingerprint).
+   * Non-terminal: the prompt remains displayed and the user may retry. */
   public void onAuthenticationFailed() {}
 
-  public void onAuthenticationHelp(int helpCode, CharSequence helpString) {
-    rustCallback(pointer, 0, helpCode);
-  }
+  /* Called with transient feedback during authentication (e.g., "Sensor dirty").
+   * Non-terminal: the prompt remains displayed, so this must not consume the Rust callback. */
+  public void onAuthenticationHelp(int helpCode, CharSequence helpString) {}
 
   public void onAuthenticationSucceeded(BiometricPrompt.AuthenticationResult result) {
-    rustCallback(pointer, 0, 0);
+    invokeOnce(0);
+  }
+
+  /* Handles a click on the prompt's negative button (set when device credential
+   * fallback is not allowed). */
+  public void onClick(DialogInterface dialog, int which) {
+    invokeOnce(BiometricPrompt.BIOMETRIC_ERROR_USER_CANCELED);
   }
 }

--- a/crates/authentication/src/sys/android/callback.rs
+++ b/crates/authentication/src/sys/android/callback.rs
@@ -13,20 +13,22 @@ const AUTHENTICATION_CALLBACK_BYTECODE: &[u8] =
 
 
 // NOTE: This must be kept in sync with the signature of `rust_callback`.
-const RUST_CALLBACK_SIGNATURE: &str = "(JII)V";
+const RUST_CALLBACK_SIGNATURE: &str = "(JI)V";
 
 // NOTE: The signature of this function must be kept in sync with
 // `RUST_CALLBACK_SIGNATURE`.
+//
+// Java's `invokeOnce` calls this at most once per pointer, so the
+// `Box::from_raw` below is sound.
 unsafe extern "C" fn rust_callback<'a>(
     _: JNIEnv<'a>,
     _: JObject<'a>,
     callback_ptr_ptr: jlong,
     error_code: jint,
-    help_code: jint,
 ) {
     // When we constructed the callback, we double-boxed it.
     let callback_ptr_boxed = unsafe {
-        Box::from_raw(callback_ptr_ptr as *mut Box<dyn Fn(Result<()>)>)
+        Box::from_raw(callback_ptr_ptr as *mut Box<dyn Fn(Result<()>) + Send>)
     };
     let callback = *callback_ptr_boxed;
 
@@ -39,6 +41,7 @@ unsafe extern "C" fn rust_callback<'a>(
             BIOMETRIC_ERROR_LOCKOUT => Error::Exhausted,
             // TODO: Differentiate between lockout and lockout permanent?
             BIOMETRIC_ERROR_LOCKOUT_PERMANENT => Error::Exhausted,
+            BIOMETRIC_ERROR_NEGATIVE_BUTTON => Error::UserCanceled,
             BIOMETRIC_ERROR_NO_BIOMETRICS => Error::Unavailable,
             BIOMETRIC_ERROR_NO_DEVICE_CREDENTIAL => Error::Unavailable,
             BIOMETRIC_ERROR_NO_SPACE => Error::Unknown,
@@ -50,13 +53,11 @@ unsafe extern "C" fn rust_callback<'a>(
             BIOMETRIC_NO_AUTHENTICATION => Error::Unavailable,
             _ => Error::Unknown,
         })
-    } else if help_code != 0 {
-        // TODO: consider returning a specific retry-able error here.
-        Err(Error::Unknown)
     } else {
         Ok(())
     };
-    callback(result);
+    // Don't let a panicking callback unwind into the JVM.
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| callback(result)));
 }
 
 static CALLBACK_CLASS: OnceLock<GlobalRef> = OnceLock::new();
@@ -125,6 +126,7 @@ const BIOMETRIC_ERROR_HW_NOT_PRESENT: i32 = 0xc;
 const BIOMETRIC_ERROR_HW_UNAVAILABLE: i32 = 1;
 const BIOMETRIC_ERROR_LOCKOUT: i32 = 7;
 const BIOMETRIC_ERROR_LOCKOUT_PERMANENT: i32 = 9;
+const BIOMETRIC_ERROR_NEGATIVE_BUTTON: i32 = 0xd;
 const BIOMETRIC_ERROR_NO_BIOMETRICS: i32 = 0xb;
 const BIOMETRIC_ERROR_NO_DEVICE_CREDENTIAL: i32 = 0xe;
 const BIOMETRIC_ERROR_NO_SPACE: i32 = 4;

--- a/crates/authentication/src/sys/android/mod.rs
+++ b/crates/authentication/src/sys/android/mod.rs
@@ -55,45 +55,81 @@ impl Context {
     where
         F: Fn(Result<()>) + Send + 'static,
     {
+        if text.android.title.is_empty() {
+            // Builder.build() throws on an empty title.
+            return Err(Error::InvalidText);
+        }
         robius_android_env::with_activity(|env, context| {
             let callback_class = callback::get_callback_class(env)?;
-            let callback_boxed_dyn = Box::new(callback) as Box<dyn Fn(Result<()>)>;
+            let callback_boxed_dyn = Box::new(callback) as Box<dyn Fn(Result<()>) + Send>;
             let callback_boxed_boxed_ptr = Box::into_raw(Box::new(callback_boxed_dyn));
-            let callback_instance = construct_callback(
-                env,
-                callback_class,
-                callback_boxed_boxed_ptr as i64,
-            )?;
-            let cancellation_signal = construct_cancellation_signal(env)?;
-            let executor = get_executor(env, context)?;
 
-            let biometric_prompt = construct_biometric_prompt(env, context, policy, &text)?;
+            // with_activity attaches the thread permanently, so on a long-lived
+            // native thread the local refs never get freed. Scope them in a local
+            // frame so the ref table doesn't overflow.
+            let result = env.with_local_frame(16, |env| {
+                show_prompt(
+                    env,
+                    context,
+                    callback_class,
+                    callback_boxed_boxed_ptr as i64,
+                    policy,
+                    &text,
+                )
+            });
 
-            env.call_method(
-                biometric_prompt,
-                "authenticate",
-                "(\
-                 Landroid/os/CancellationSignal;\
-                 Ljava/util/concurrent/Executor;\
-                 Landroid/hardware/biometrics/BiometricPrompt$AuthenticationCallback;\
-                 )V",
-                &[
-                    JValueGen::Object(&cancellation_signal),
-                    JValueGen::Object(&executor),
-                    JValueGen::Object(&callback_instance),
-                ],
-            )?;
-
-            Ok(())
+            if result.is_err() {
+                // Prompt never showed, so Java won't invoke or free the callback.
+                // Free it here so it doesn't leak.
+                if env.exception_check().unwrap_or(false) {
+                    let _ = env.exception_clear();
+                }
+                drop(unsafe { Box::from_raw(callback_boxed_boxed_ptr) });
+            }
+            result
         })
-        .map_err(|e| Error::Java(e))?
+        .map_err(Error::from)?
     }
+}
+
+fn show_prompt(
+    env: &mut JNIEnv<'_>,
+    context: &JObject<'_>,
+    callback_class: &GlobalRef,
+    callback_box_ptr: i64,
+    policy: &Policy,
+    text: &Text,
+) -> Result<()> {
+    let callback_instance = construct_callback(env, callback_class, callback_box_ptr)?;
+    let cancellation_signal = construct_cancellation_signal(env)?;
+    let executor = get_executor(env, context)?;
+
+    let biometric_prompt =
+        construct_biometric_prompt(env, context, policy, text, &executor, &callback_instance)?;
+
+    // Once authenticate returns, the framework holds its own ref to the callback,
+    // so our local refs can be dropped.
+    env.call_method(
+        biometric_prompt,
+        "authenticate",
+        "(\
+         Landroid/os/CancellationSignal;\
+         Ljava/util/concurrent/Executor;\
+         Landroid/hardware/biometrics/BiometricPrompt$AuthenticationCallback;\
+         )V",
+        &[
+            JValueGen::Object(&cancellation_signal),
+            JValueGen::Object(&executor),
+            JValueGen::Object(&callback_instance),
+        ],
+    )?;
+
+    Ok(())
 }
 
 #[derive(Debug)]
 pub(crate) struct Policy {
-    #[allow(dead_code)]
-    strength: BiometricStrength,
+    strength: Option<BiometricStrength>,
     password: bool,
 }
 
@@ -139,13 +175,15 @@ impl PolicyBuilder {
     }
 
     pub(crate) const fn build(self) -> Option<Policy> {
-        if let Some(strength) = self.biometrics {
-            return Some(Policy {
-                strength,
-                password: self.password,
-            });
+        // Need at least one method on. Biometrics-only, credential-only (API 29+),
+        // and both are all fine with BiometricPrompt.
+        if self.biometrics.is_none() && !self.password {
+            return None;
         }
-        None
+        Some(Policy {
+            strength: self.biometrics,
+            password: self.password,
+        })
     }
 }
 
@@ -182,13 +220,38 @@ fn construct_biometric_prompt<'a>(
     context: &JObject<'_>,
     policy: &Policy,
     text: &Text,
+    executor: &JObject<'_>,
+    negative_button_listener: &JObject<'_>,
 ) -> Result<JObject<'a>> {
-    let context = env.new_global_ref(context).unwrap();
+    // `BiometricManager.Authenticators` constants.
+    const STRONG: i32 = 0xf;
+    const WEAK: i32 = 0xff;
+    const CREDENTIAL: i32 = 0x8000;
+    // `android.R.string.cancel`, a stable public resource ID.
+    const ANDROID_R_STRING_CANCEL: i32 = 17039360;
+
+    let sdk_int = env
+        .get_static_field("android/os/Build$VERSION", "SDK_INT", "I")?
+        .i()?;
+
+    let biometrics_mask = match policy.strength {
+        Some(BiometricStrength::Strong) => STRONG,
+        Some(BiometricStrength::Weak) => WEAK,
+        None => 0,
+    };
+    // Device credential (PIN/pattern/password) fallback needs API 29+
+    // (setDeviceCredentialAllowed) or API 30+ (setAllowedAuthenticators).
+    let credential_allowed = policy.password && sdk_int >= 29;
+
+    if biometrics_mask == 0 && !credential_allowed {
+        // Credential-only doesn't work before API 29.
+        return Err(Error::Unavailable);
+    }
 
     let builder = env.new_object(
         "android/hardware/biometrics/BiometricPrompt$Builder",
         "(Landroid/content/Context;)V",
-        &[JValueGen::Object(context.as_ref())],
+        &[JValueGen::Object(context)],
     )?;
 
     env.call_method(
@@ -216,21 +279,52 @@ fn construct_biometric_prompt<'a>(
             &[JValueGen::Object(&env.new_string(description)?.into())],
         )?;
     }
-    const STRONG: i32 = 0xf;
-    const WEAK: i32 = 0xff;
-    const CREDENTIAL: i32 = 0x8000;
 
-    env.call_method(
-        &builder,
-        "setAllowedAuthenticators",
-        "(I)Landroid/hardware/biometrics/BiometricPrompt$Builder;",
-        &[JValueGen::Int(
-            match policy.strength {
-                BiometricStrength::Strong => STRONG,
-                BiometricStrength::Weak => WEAK,
-            } | if policy.password { CREDENTIAL } else { 0 },
-        )],
-    )?;
+    if sdk_int >= 30 {
+        env.call_method(
+            &builder,
+            "setAllowedAuthenticators",
+            "(I)Landroid/hardware/biometrics/BiometricPrompt$Builder;",
+            &[JValueGen::Int(
+                biometrics_mask | if credential_allowed { CREDENTIAL } else { 0 },
+            )],
+        )?;
+    } else if credential_allowed {
+        // API 29: `setAllowedAuthenticators` doesn't exist yet.
+        env.call_method(
+            &builder,
+            "setDeviceCredentialAllowed",
+            "(Z)Landroid/hardware/biometrics/BiometricPrompt$Builder;",
+            &[JValueGen::Bool(1)],
+        )?;
+    }
+
+    if !credential_allowed {
+        // Framework wants a negative button when there's no credential fallback;
+        // build() throws otherwise.
+        let cancel_text = env
+            .call_method(
+                context,
+                "getString",
+                "(I)Ljava/lang/String;",
+                &[JValueGen::Int(ANDROID_R_STRING_CANCEL)],
+            )?
+            .l()?;
+        env.call_method(
+            &builder,
+            "setNegativeButton",
+            "(\
+             Ljava/lang/CharSequence;\
+             Ljava/util/concurrent/Executor;\
+             Landroid/content/DialogInterface$OnClickListener;\
+             )Landroid/hardware/biometrics/BiometricPrompt$Builder;",
+            &[
+                JValueGen::Object(&cancel_text),
+                JValueGen::Object(executor),
+                JValueGen::Object(negative_button_listener),
+            ],
+        )?;
+    }
 
     env.call_method(
         builder,

--- a/crates/authentication/src/sys/apple.rs
+++ b/crates/authentication/src/sys/apple.rs
@@ -1,5 +1,4 @@
 use block2::RcBlock;
-use objc2::rc::Retained;
 use objc2_foundation::{NSError, NSString};
 use objc2_local_authentication::{LAContext, LAError, LAPolicy};
 // #[cfg(feature = "async")]
@@ -10,15 +9,11 @@ use crate::{BiometricStrength, Error, Result, Text};
 pub(crate) type RawContext = ();
 
 #[derive(Debug)]
-pub(crate) struct Context {
-    inner: Retained<LAContext>,
-}
+pub(crate) struct Context;
 
 impl Context {
     pub(crate) fn new(_: RawContext) -> Self {
-        Self {
-            inner: unsafe { LAContext::new() },
-        }
+        Self
     }
     // TODO: Fix the async authenticate function
     //
@@ -53,11 +48,25 @@ impl Context {
     where
         F: Fn(Result<()>) + Send + 'static
     {
-        unsafe { self.inner.canEvaluatePolicy_error(policy.inner) }.map_err(|err| {
+        // An empty reason makes evaluatePolicy throw NSInvalidArgumentException,
+        // which aborts the app, so bail early.
+        if text.apple.is_empty() {
+            return Err(Error::InvalidText);
+        }
+
+        // An LAContext is single-use: reuse one and a past success lets the next
+        // call skip the prompt. Make a fresh one each time.
+        let context = unsafe { LAContext::new() };
+
+        unsafe { context.canEvaluatePolicy_error(policy.inner) }.map_err(|err| {
             Error::from(LAError(err.code()))
         })?;
 
+        // The eval is async and the context has to stay alive until the reply
+        // fires, so move a strong ref into the block.
+        let context_keepalive = context.clone();
         let block = RcBlock::new(move |is_success, error: *mut NSError| {
+            let _keep_alive = &context_keepalive;
             let arg = bool::from(is_success)
                 .then_some(())
                 .ok_or_else(|| {
@@ -69,11 +78,13 @@ impl Context {
                         Error::from(laerror)
                     }
                 });
-            callback(arg)
+            // This runs on a framework queue, so don't let a panicking callback
+            // unwind across the ObjC frame.
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| callback(arg)));
         });
 
         unsafe {
-            self.inner.evaluatePolicy_localizedReason_reply(
+            context.evaluatePolicy_localizedReason_reply(
                 policy.inner,
                 &NSString::from_str(text.apple),
                 &block,
@@ -201,12 +212,13 @@ impl PolicyBuilder {
                 _companion: true,
                 ..
             } => {
-                // This crashes the app on iOS (at least on the simulator).
+                // Companion-only isn't supported on iOS (it crashes), so call it
+                // invalid instead of silently swapping in passcode auth.
                 #[cfg(not(target_os = "ios"))] {
                     LAPolicy::DeviceOwnerAuthenticationWithCompanion
                 }
                 #[cfg(target_os = "ios")] {
-                    LAPolicy::DeviceOwnerAuthentication
+                    return None
                 }
             },
             _ => return None,

--- a/crates/authentication/src/sys/linux/mod.rs
+++ b/crates/authentication/src/sys/linux/mod.rs
@@ -78,14 +78,26 @@ fn do_polkit_check(action_id: &str) -> Result<()> {
                     "org.freedesktop.PolicyKit1.Error.NotAuthorized" => Error::Authentication,
                     "org.freedesktop.PolicyKit1.Error.NotSupported" => Error::Unavailable,
                     "org.freedesktop.PolicyKit1.Error.NoAgent" => Error::Unavailable,
-                    _ => Error::Authentication,
+                    // Fires for an unregistered action or rejected details, before
+                    // any prompt — we couldn't evaluate it, the user didn't fail.
+                    "org.freedesktop.PolicyKit1.Error.Failed" => Error::Unavailable,
+                    // D-Bus transport errors show up here (not as FDO) since the
+                    // polkit proxy returns a plain zbus::Result.
+                    "org.freedesktop.DBus.Error.NoReply"
+                    | "org.freedesktop.DBus.Error.Timeout"
+                    | "org.freedesktop.DBus.Error.TimedOut"
+                    | "org.freedesktop.DBus.Error.ServiceUnknown"
+                    | "org.freedesktop.DBus.Error.NameHasNoOwner"
+                    | "org.freedesktop.DBus.Error.NoServer"
+                    | "org.freedesktop.DBus.Error.Disconnected" => Error::Unavailable,
+                    _ => Error::Unknown,
                 },
                 ZbusError::FDO(fdo_err) => match *fdo_err {
                     fdo::Error::TimedOut(_) | fdo::Error::NoReply(_) => Error::Unavailable,
-                    _ => Error::Authentication,
+                    _ => Error::Unknown,
                 },
                 ZbusError::InputOutput(_) => Error::Unavailable,
-                _ => Error::Authentication,
+                _ => Error::Unknown,
             }
         })?;
 
@@ -102,9 +114,13 @@ fn do_polkit_check(action_id: &str) -> Result<()> {
         return Err(Error::UserCanceled);
     }
 
+    // is_challenge means polkit wanted to prompt but never got an answer —
+    // usually no agent is running. That's unavailable, not a failed login.
+    if result.is_challenge {
+        return Err(Error::Unavailable);
+    }
 
-    // If we're not authorized, treat as authentication failure.
-    // "NoAgent" is handled as an error (org.freedesktop.PolicyKit1.Error.NoAgent).
+    // Otherwise the action is just denied for this subject.
     Err(Error::Authentication)
 }
 

--- a/crates/authentication/src/sys/unsupported.rs
+++ b/crates/authentication/src/sys/unsupported.rs
@@ -21,8 +21,11 @@ impl Context {
     //     Err(Error::Unknown)
     // }
 
-    pub(crate) fn authenticate(&self, _: Text, _: &Policy) -> Result<()> {
-        Err(Error::Unknown)
+    pub(crate) fn authenticate<F>(&self, _: Text, _: &Policy, _: F) -> Result<()>
+    where
+        F: Fn(Result<()>) + Send + 'static,
+    {
+        Err(Error::Unavailable)
     }
 }
 

--- a/crates/authentication/src/sys/windows/fallback.rs
+++ b/crates/authentication/src/sys/windows/fallback.rs
@@ -3,21 +3,23 @@ use std::ffi::c_void;
 use windows::{
     core::{PCWSTR, PSTR},
     Win32::{
-        Foundation::{ERROR_CANCELLED, HANDLE, HWND, NO_ERROR, WIN32_ERROR},
+        Foundation::{CloseHandle, ERROR_CANCELLED, HANDLE, HWND, NO_ERROR, WIN32_ERROR},
         Graphics::Gdi::HBITMAP,
-        NetworkManagement::NetManagement::UNLEN,
         Security::{
             Authentication::Identity::{
-                GetUserNameExW, LsaConnectUntrusted, LsaLookupAuthenticationPackage,
-                NameSamCompatible, LSA_STRING, MSV1_0_PACKAGE_NAME,
+                GetUserNameExW, LsaConnectUntrusted, LsaDeregisterLogonProcess,
+                LsaLookupAuthenticationPackage, NameSamCompatible, LSA_STRING,
+                MSV1_0_PACKAGE_NAME,
             },
             Credentials::{
                 CredUIParseUserNameW, CredUIPromptForWindowsCredentialsW,
-                CredUnPackAuthenticationBufferW, CREDUIWIN_FLAGS, CREDUI_INFOW,
-                CREDUI_MAX_DOMAIN_TARGET_LENGTH, CRED_PACK_PROTECTED_CREDENTIALS,
+                CredUnPackAuthenticationBufferW, CREDUIWIN_ENUMERATE_CURRENT_USER, CREDUI_INFOW,
+                CREDUI_MAX_DOMAIN_TARGET_LENGTH, CREDUI_MAX_USERNAME_LENGTH,
+                CRED_PACK_PROTECTED_CREDENTIALS,
             },
             LogonUserW, LOGON32_LOGON_INTERACTIVE, LOGON32_PROVIDER_DEFAULT,
         },
+        System::Com::CoTaskMemFree,
     },
 };
 use windows_core::PWSTR;
@@ -25,7 +27,9 @@ use windows_core::PWSTR;
 use crate::{text::WindowsText, Error, Result};
 
 // Add one to include null byte.
-const MAX_USERNAME_LENGTH: usize = UNLEN as usize + 1;
+// NOTE: the unpacked name is DOMAIN\user, so size it for the whole thing
+// (CREDUI_MAX_USERNAME_LENGTH), not just the account name.
+const MAX_USERNAME_LENGTH: usize = CREDUI_MAX_USERNAME_LENGTH as usize + 1;
 const MAX_DOMAIN_LENGTH: usize = CREDUI_MAX_DOMAIN_TARGET_LENGTH as usize + 1;
 const MAX_PASSWORD_LENGTH: usize = 256 + 1;
 
@@ -35,11 +39,31 @@ type Password = [u16; MAX_PASSWORD_LENGTH];
 
 pub(super) fn authenticate(text: WindowsText) -> Result<()> {
     let (auth_buf, auth_buf_size) = ui_prompt(text)?;
-    let ((username, username_size), password) =
-        unpack_authentication_buffer(auth_buf, auth_buf_size)?;
+    let unpacked = unpack_authentication_buffer(auth_buf, auth_buf_size);
+    // CredUI docs say to zero the credential blob and free it with CoTaskMemFree
+    // once we're done with it.
+    unsafe {
+        std::ptr::write_bytes(auth_buf as *mut u8, 0, auth_buf_size as usize);
+        CoTaskMemFree(Some(auth_buf));
+    }
+    let ((username, username_size), mut password) = unpacked?;
 
+    let result = check_and_logon(username, username_size, &mut password);
+    // Zero our plaintext password copy, best effort.
+    for c in password.iter_mut() {
+        unsafe { std::ptr::write_volatile(c, 0) };
+    }
+    result
+}
+
+fn check_and_logon(
+    username: Username,
+    username_size: usize,
+    password: &mut Password,
+) -> Result<()> {
     let (current_user, current_user_size) = current_user()?;
-    if username[..username_size] != current_user[..current_user_size] {
+    // Windows account names are case-insensitive.
+    if !eq_ignore_case(&username[..username_size], &current_user[..current_user_size]) {
         return Err(Error::Authentication);
     }
 
@@ -47,12 +71,25 @@ pub(super) fn authenticate(text: WindowsText) -> Result<()> {
     logon_user(account_name, domain, password)
 }
 
+/// Compares two UTF-16 strings case-insensitively, ignoring trailing nulls.
+fn eq_ignore_case(a: &[u16], b: &[u16]) -> bool {
+    let a = String::from_utf16_lossy(a);
+    let b = String::from_utf16_lossy(b);
+    a.trim_end_matches('\0').to_lowercase() == b.trim_end_matches('\0').to_lowercase()
+}
+
 fn ui_prompt(text: WindowsText) -> Result<(*mut c_void, u32)> {
     // _message and _caption can only be dropped after we've used ui.
     let (_message, _caption, ui) = ui(text);
 
     let handle = handle()?;
-    let mut auth_package = auth_package(handle)?;
+    let auth_package_result = auth_package(handle);
+    // We only needed the LSA handle to look up the auth package, so close it
+    // either way — otherwise it leaks a kernel handle per prompt.
+    unsafe {
+        let _ = LsaDeregisterLogonProcess(handle);
+    }
+    let mut auth_package = auth_package_result?;
 
     let mut auth_buf = std::ptr::null_mut();
     let mut auth_buf_size = 0u32;
@@ -67,7 +104,7 @@ fn ui_prompt(text: WindowsText) -> Result<(*mut c_void, u32)> {
             &mut auth_buf as *mut _,
             &mut auth_buf_size as *mut _,
             None,
-            CREDUIWIN_FLAGS(0x200),
+            CREDUIWIN_ENUMERATE_CURRENT_USER,
         )
     };
 
@@ -169,22 +206,21 @@ fn unpack_authentication_buffer(
 }
 
 fn current_user() -> Result<(Username, usize)> {
-    let mut username = [0; MAX_USERNAME_LENGTH];
+    let mut username = [0u16; MAX_USERNAME_LENGTH];
     let mut username_size = username.len() as u32;
 
     let is_ok = unsafe {
         GetUserNameExW(
             NameSamCompatible,
-            PWSTR(&mut username as *mut _),
+            PWSTR(username.as_mut_ptr()),
             &mut username_size as *mut _,
         )
     }
     .as_bool();
 
     if is_ok {
-        // The size returned by GetUserNameExW doesn't include the null byte for some
-        // reason :)
-        Ok((username, username_size as usize + 1))
+        // `GetUserNameExW` reports the length excluding the null terminator.
+        Ok((username, username_size as usize))
     } else {
         Err(Error::Unknown)
     }
@@ -214,10 +250,10 @@ fn parse_username(
 fn logon_user(
     mut account_name: Username,
     mut domain: Domain,
-    mut password: Password,
+    password: &mut Password,
 ) -> Result<()> {
-    let mut _handle = HANDLE(0);
-    unsafe {
+    let mut token = HANDLE(0);
+    let result = unsafe {
         LogonUserW(
             PWSTR(account_name.as_mut_ptr()),
             PWSTR(domain.as_mut_ptr()),
@@ -226,8 +262,17 @@ fn logon_user(
             LOGON32_PROVIDER_DEFAULT,
             // If we pass in a null pointer here, Windows silently succeeds regardless of the
             // password provided ... thanks Windows.
-            &mut _handle as *mut _,
+            &mut token as *mut _,
         )
     }
-    .map_err(|_| Error::Authentication)
+    .map_err(|_| Error::Authentication);
+
+    // LogonUserW hands back a token handle on success that we have to close.
+    if !token.is_invalid() {
+        unsafe {
+            let _ = CloseHandle(token);
+        }
+    }
+
+    result
 }

--- a/crates/authentication/src/sys/windows/mod.rs
+++ b/crates/authentication/src/sys/windows/mod.rs
@@ -9,6 +9,10 @@ use windows::{
     Security::Credentials::UI::{
         UserConsentVerificationResult, UserConsentVerifier, UserConsentVerifierAvailability,
     },
+    Win32::{
+        Foundation::RPC_E_CHANGED_MODE,
+        System::Com::{CoInitializeEx, CoUninitialize, COINIT_MULTITHREADED},
+    },
 };
 
 use crate::{text::WindowsText, BiometricStrength, Error, Result, Text};
@@ -51,18 +55,64 @@ impl Context {
     where
         F: Fn(Result<()>) + Send + 'static,
     {
-        // NOTE: If we don't check availability, `request_verification` will hang.
-        let available =
-            check_availability()?.get() == Ok(UserConsentVerifierAvailability::Available);
-
-        let result = if available {
-            let verification = request_verification(message.windows)?;
-            convert(verification.get()?)
-        } else {
-            fallback::authenticate(message.windows)
-        };
-        callback(result);
+        // WindowsText borrows from the caller, so copy the strings for the thread.
+        let title = message.windows.title.to_owned();
+        let description = message.windows.description.to_owned();
+        // The availability check and the prompts all block until the user answers,
+        // so run them off the caller thread and don't freeze the UI.
+        std::thread::Builder::new()
+            .name("robius-authentication".into())
+            .spawn(move || {
+                let text = WindowsText {
+                    title: &title,
+                    description: &description,
+                };
+                // New thread has no COM apartment, and blocking on
+                // IAsyncOperation::get() needs an MTA, so set one up for it.
+                let com = ComGuard::new_multithreaded();
+                callback(authenticate_blocking(text));
+                drop(com);
+            })
+            .map_err(|_| Error::Unavailable)?;
         Ok(())
+    }
+}
+
+/// Sets up a COM multithreaded apartment for this thread and uninitializes it
+/// on drop, unless the thread was already in a different apartment.
+struct ComGuard {
+    should_uninit: bool,
+}
+
+impl ComGuard {
+    fn new_multithreaded() -> Self {
+        let hr = unsafe { CoInitializeEx(None, COINIT_MULTITHREADED) };
+        // S_OK/S_FALSE mean we init'd and owe a CoUninitialize. RPC_E_CHANGED_MODE
+        // means the thread's already in another apartment, so leave it alone.
+        Self {
+            should_uninit: hr != RPC_E_CHANGED_MODE,
+        }
+    }
+}
+
+impl Drop for ComGuard {
+    fn drop(&mut self) {
+        if self.should_uninit {
+            unsafe { CoUninitialize() };
+        }
+    }
+}
+
+fn authenticate_blocking(text: WindowsText<'_, '_>) -> Result<()> {
+    // NOTE: If we don't check availability, `request_verification` will hang.
+    let available =
+        check_availability()?.get() == Ok(UserConsentVerifierAvailability::Available);
+
+    if available {
+        let verification = request_verification(text)?;
+        convert(verification.get()?)
+    } else {
+        fallback::authenticate(text)
     }
 }
 
@@ -78,28 +128,27 @@ impl Policy {
 
 #[derive(Debug)]
 pub(crate) struct PolicyBuilder {
-    valid: bool,
+    biometrics: bool,
+    password: bool,
 }
 
 impl PolicyBuilder {
     pub(crate) const fn new() -> Self {
-        Self { valid: true }
+        Self {
+            biometrics: true,
+            password: true,
+        }
     }
 
     pub(crate) const fn biometrics(self, biometrics: Option<BiometricStrength>) -> Self {
-        if biometrics.is_none() {
-            Self { valid: false }
-        } else {
-            self
+        Self {
+            biometrics: biometrics.is_some(),
+            ..self
         }
     }
 
     pub(crate) const fn password(self, password: bool) -> Self {
-        if password {
-            self
-        } else {
-            Self { valid: false }
-        }
+        Self { password, ..self }
     }
 
     pub(crate) const fn companion(self, _: bool) -> Self {
@@ -115,7 +164,9 @@ impl PolicyBuilder {
     }
 
     pub(crate) const fn build(self) -> Option<Policy> {
-        if self.valid {
+        // Windows Hello always allows PIN and the fallback is password-based, so
+        // we can't honor a policy that turns either one off.
+        if self.biometrics && self.password {
             Some(Policy)
         } else {
             None
@@ -131,9 +182,7 @@ fn check_availability() -> Result<IAsyncOperation<UserConsentVerifierAvailabilit
 fn request_verification(
     text: WindowsText,
 ) -> Result<IAsyncOperation<UserConsentVerificationResult>> {
-    let caption = caption(text.description);
-
-    UserConsentVerifier::RequestVerificationAsync(&HSTRING::from_wide(&caption[..])?)
+    UserConsentVerifier::RequestVerificationAsync(&HSTRING::from(text.description))
         .map_err(|e| e.into())
 }
 
@@ -209,7 +258,6 @@ fn request_verification(
     }
 
     let window = unsafe { GetDesktopWindow() };
-    let caption = caption(text.description);
 
     let factory = factory::<UserConsentVerifier, IUserConsentVerifierInterop>()?;
 
@@ -217,32 +265,25 @@ fn request_verification(
         IUserConsentVerifierInterop::RequestVerificationForWindowAsync(
             &factory,
             window,
-            &HSTRING::from_wide(&caption[..])?,
+            // NOTE: HSTRING is length-prefixed, so no null terminator; `from`
+            // does the UTF-16 conversion.
+            &HSTRING::from(text.description),
         )
     }?;
 
-    focus_security_prompt()?;
+    // Focusing is just a nice-to-have and the prompt's already up, so don't fail
+    // auth if it doesn't work.
+    let _ = focus_security_prompt();
 
     Ok(op)
-}
-
-fn caption(message: &str) -> Vec<u16> {
-    let mut caption = Vec::with_capacity(message.len());
-
-    for c in message.encode_utf16() {
-        caption.push(c);
-    }
-    caption.push(0);
-
-    caption
 }
 
 fn convert(result: UserConsentVerificationResult) -> Result<()> {
     match result {
         UserConsentVerificationResult::Verified => Ok(()),
         UserConsentVerificationResult::DeviceNotPresent => Err(Error::Unavailable),
-        UserConsentVerificationResult::NotConfiguredForUser => Err(Error::Unavailable),
-        UserConsentVerificationResult::DisabledByPolicy => Err(Error::Unavailable),
+        UserConsentVerificationResult::NotConfiguredForUser => Err(Error::NotConfigured),
+        UserConsentVerificationResult::DisabledByPolicy => Err(Error::DisabledByPolicy),
         UserConsentVerificationResult::DeviceBusy => Err(Error::Busy),
         UserConsentVerificationResult::RetriesExhausted => Err(Error::Exhausted),
         UserConsentVerificationResult::Canceled => Err(Error::UserCanceled),

--- a/crates/authentication/src/text.rs
+++ b/crates/authentication/src/text.rs
@@ -48,8 +48,10 @@ impl<'a, 'b> WindowsText<'a, 'b> {
 
     /// Creates a new `WindowsText` instance.
     ///
-    /// Returns `None` if `title` exceeds 128 bytes in length
-    /// or if `description` exceeds 1024 bytes in length.
+    /// On Windows, returns `None` if `title` exceeds 128 bytes in length
+    /// or if `description` exceeds 1024 bytes in length. On other targets the
+    /// text is unused, so no validation is performed and this always returns
+    /// `Some`.
     #[cfg(not(target_os = "windows"))]
     pub const fn new(title: &'a str, description: &'b str) -> Option<Self> {
         Some(Self { title, description })
@@ -57,28 +59,45 @@ impl<'a, 'b> WindowsText<'a, 'b> {
 
     /// Creates a new `WindowsText` instance.
     ///
-    /// The `title` ("caption") will be truncated to 128 bytes in length,
-    /// and the `description` ("message") will be truncated to 1024 bytes in length.
+    /// The `title` ("caption") will be truncated to at most 128 bytes in length,
+    /// and the `description` ("message") will be truncated to at most 1024 bytes in length.
+    /// Truncation respects UTF-8 character boundaries, so fewer bytes may be kept.
     #[cfg(target_os = "windows")]
     pub fn new_truncated(title: &'a str, description: &'b str) -> Self {
         use windows::Win32::Security::Credentials::{
             CREDUI_MAX_CAPTION_LENGTH, CREDUI_MAX_MESSAGE_LENGTH,
         };
 
-        let title_max_len = std::cmp::min(CREDUI_MAX_CAPTION_LENGTH as usize, title.len());
-        let description_max_len = std::cmp::min(CREDUI_MAX_MESSAGE_LENGTH as usize, description.len());
         Self {
-            title: &title[..title_max_len],
-            description: &description[..description_max_len],
+            title: truncate_to_char_boundary(title, CREDUI_MAX_CAPTION_LENGTH as usize),
+            description: truncate_to_char_boundary(
+                description,
+                CREDUI_MAX_MESSAGE_LENGTH as usize,
+            ),
         }
     }
 
     /// Creates a new `WindowsText` instance.
     ///
-    /// The `title` ("caption") will be truncated to 128 bytes in length,
-    /// and the `description` ("message") will be truncated to 1024 bytes in length.
+    /// On Windows, the `title` ("caption") is truncated to at most 128 bytes and
+    /// the `description` ("message") to at most 1024 bytes, respecting UTF-8
+    /// character boundaries. On other targets the text is unused and is stored
+    /// verbatim without truncation.
     #[cfg(not(target_os = "windows"))]
     pub fn new_truncated(title: &'a str, description: &'b str) -> Self {
         Self { title, description }
     }
+}
+
+/// Truncates `s` to at most `max_len` bytes without splitting a UTF-8 character.
+#[cfg(target_os = "windows")]
+fn truncate_to_char_boundary(s: &str, max_len: usize) -> &str {
+    if s.len() <= max_len {
+        return s;
+    }
+    let mut end = max_len;
+    while !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
 }


### PR DESCRIPTION
* fix build on unsupported platforms and Android's error variant
* On Apple platforms, use a new `LAContext` for every call
* On Android, ensure the auth callback can ever only be invoked once. And properly handle differences in API levels (and document them)
* On windows, move the auth call off of the main UI thread, plus a few other minor improvements
* On linux, be more specific about the errors that could occur

The full list of generated details are below:

-------------

Build breakage
- Fix Android backend not compiling: Error::Java now wraps Arc, so
  construct via Error::from instead of a bare jni error.
- Fix unsupported-target backend: add the missing `callback` param to
  authenticate(), which broke every fallback target (incl. wasm).
- Drop nightly `#![feature(const_option)]` from the lib doctest and stop
  using const Option::unwrap in the example; both broke stable + MSRV 1.77.

Apple
- Create a fresh LAContext per authenticate() call instead of reusing one
  (reuse could let a prior success skip verification), and move a strong
  ref into the reply block so the context outlives the call.
- Reject an empty reason string up front (empty reason aborts via
  NSInvalidArgumentException).
- Wrap the user callback in catch_unwind (was unwinding across the ObjC
  reply block).
- Return None for companion-only policies on iOS instead of silently
  falling back to device-passcode auth.

Android
- Invoke the Rust callback exactly once (guarded invokeOnce in Java);
  onAuthenticationHelp no longer frees the callback (was a use-after-free),
  and the negative-button click maps to UserCanceled.
- Gate authenticators by API level: setAllowedAuthenticators only >= 30,
  setDeviceCredentialAllowed on 29, error below 29 for credential-only;
  set the required negative button when credential fallback is disallowed.
- Allow credential-only policies (biometrics(None)) to build.
- Scope JNI local refs in a local frame (were leaking unbounded on a
  permanently-attached native thread); reclaim the callback box and clear
  pending exceptions on error paths; drop a panicking .unwrap().
- Reject an empty prompt title (Builder.build() throws on it).

Windows
- Run authentication off the caller thread (was blocking the UI thread),
  initializing an MTA COM apartment for the WinRT calls.
- fallback: free (CoTaskMemFree) and zero the credential blob, zero the
  password copy, close the LogonUser token and LSA handles, size the
  username buffer for DOMAIN\user, and compare usernames case-insensitively.
- Map NotConfiguredForUser/DisabledByPolicy results to their own Error
  variants; a focus-prompt failure no longer aborts an already-shown prompt.
- Reject biometrics/password-disabled policies in build().

Linux
- Map unregistered-action and D-Bus transport errors to Unavailable
  (not "authentication failed"), handle is_challenge (no agent running)
  as Unavailable, and default unknown errors to Unknown.

Text / errors / docs
- text: truncate WindowsText on UTF-8 char boundaries (was panicking on
  non-ASCII input at the byte cutoff).
- error: implement Display and std::error::Error; add an InvalidText
  variant for empty prompt text.
- Add Win32_System_Com to the windows features for CoInitializeEx/CoTaskMemFree.
- Fix doc typos and the callback-contract wording, correct the "winrt-based
  fallback" description, and document the minimum Android API level
  (28 for biometrics, 29 for password fallback) in lib.rs and the README.
