### PR TITLE
Clearly document the minimum Android API level supported by each crate

### DIFF
--- a/crates/authentication/build.rs
+++ b/crates/authentication/build.rs
@@ -6,9 +6,6 @@ fn main() {
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
 
     if target_os == "android" {
-        // android-build already emits rerun-if-env-changed for the SDK/JDK env
-        // vars it reads (ANDROID_HOME, ANDROID_PLATFORM, JAVA_HOME, etc.), so we
-        // only track the Java source here.
         println!("cargo:rerun-if-changed={JAVA_FILE_RELATIVE_PATH}");
 
         let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());

--- a/crates/file-picker/README.md
+++ b/crates/file-picker/README.md
@@ -9,6 +9,9 @@ Rust abstractions for native file picker dialogs, including dedicated image and 
    * On Android 10 and up, it can save directly to "Downloads" via `MediaStore.Downloads`.
    * On Android 8 an 9, it writes directly to storage when the legacy external storage write permission
      is granted, and otherwise falls back to `ACTION_CREATE_DOCUMENT`.
+   * **Minimum API level: 26 (Android 8.0).** The bundled Java helper is loaded via `InMemoryDexClassLoader`,
+     which requires API 26. Newer features (the system Photo Picker, `MediaStore.Downloads`) are used only
+     when the device supports them, so set `minSdk` to at least 26.
 * iOS: file operations use `UIDocumentPickerViewController`, media picking uses`PHPickerViewController`.
 
 All completion callbacks run on a background thread (a native OS thread, not an async task).

--- a/crates/file-picker/src/lib.rs
+++ b/crates/file-picker/src/lib.rs
@@ -13,7 +13,11 @@
 //!   * On Android 10 and up, it saves directly to Downloads via `MediaStore.Downloads`.
 //!   * On Android 8 and 9, it writes directly to storage if the legacy external storage
 //!     write permission is granted. Otherwise it falls back to `ACTION_CREATE_DOCUMENT`.
-//! * **iOS**: file picking use [`UIDocumentPickerViewController`], while 
+//!   * **Minimum API level: 26 (Android 8.0).** The bundled Java helper is loaded via
+//!     `InMemoryDexClassLoader`, which requires API 26. Newer features (the system
+//!     Photo Picker, `MediaStore.Downloads`) are used only when the device supports
+//!     them, so set `minSdk` to at least 26 in your app.
+//! * **iOS**: file picking use [`UIDocumentPickerViewController`], while
 //!   media picking uses `PHPickerViewController`.
 //!
 //! On Android, picked files are returned as `content://` URIs (there's no other real option),

--- a/crates/location/README.md
+++ b/crates/location/README.md
@@ -33,4 +33,9 @@ As specified in the [Android documentation][android-docs].
 
 Note that these go in the `manifest` key section, not the `application` section.
 
+### Minimum API level
+The minimum supported Android API level is **26 (Android 8.0)**: the bundled Java helper is loaded via
+`InMemoryDexClassLoader`, which requires API 26. Newer location APIs (e.g. `getCurrentLocation`) are used only
+when the device supports them, with a fallback for older versions, so set `minSdk` to at least 26 in your app.
+
 [android-docs]: https://developer.android.com/develop/sensors-and-location/location/permissions

--- a/crates/location/src/lib.rs
+++ b/crates/location/src/lib.rs
@@ -14,6 +14,14 @@
 //! ```
 //! As specified in the [Android documentation][android-docs].
 //!
+//! ### Minimum API level
+//!
+//! The minimum supported Android API level is **26 (Android 8.0)**: the bundled
+//! Java helper is loaded via `InMemoryDexClassLoader`, which requires API 26.
+//! Newer location APIs (e.g. `getCurrentLocation`) are used only when the device
+//! supports them, with a fallback for older versions, so set `minSdk` to at least
+//! 26 in your app.
+//!
 //! [android-docs]: https://developer.android.com/develop/sensors-and-location/location/permissions
 
 mod error;

--- a/crates/share/README.md
+++ b/crates/share/README.md
@@ -33,6 +33,10 @@ attachments are copied to a shareable MediaStore item on Android 10 and newer.
 On Android 8 and 9, API 26 through 28, text files can be shared as text
 content; arbitrary binary path attachments require a host-app `ContentProvider`.
 
+The **minimum supported Android API level is 26 (Android 8.0)**: the bundled Java
+helper is loaded via `InMemoryDexClassLoader`, which requires API 26, so set
+`minSdk` to at least 26 in your app.
+
 ## Android file attachments
 
 Android receivers should be given `content://` URIs, not private app filesystem

--- a/crates/share/src/lib.rs
+++ b/crates/share/src/lib.rs
@@ -11,6 +11,9 @@
 //!     Android 10 and newer. On older Android versions, text files can be shared
 //!     as text content, but arbitrary binary path attachments require an app
 //!     `ContentProvider`.
+//!   * **Minimum API level: 26 (Android 8.0).** The bundled Java helper is loaded
+//!     via `InMemoryDexClassLoader`, which requires API 26. Set `minSdk` to at
+//!     least 26 in your app.
 //! * **iOS**: sharing uses `UIActivityViewController`, with text, URLs, and
 //!   filesystem path attachments.
 //! * **macOS**: sharing uses `NSSharingServicePicker`, with text, URLs, and


### PR DESCRIPTION
generally our target is API level 26 and up, but biometric auth is the one exception since it didn't exist prior to API level 28.