### PR TITLE
Relax dependency on `zbus`, lower MSRVs where possible 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "robius-authentication"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "android-build",
  "block2",
@@ -1000,11 +1000,11 @@ dependencies = [
 
 [[package]]
 name = "robius-common"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 name = "robius-directories"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "bencher",
  "dirs-sys",
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "robius-file-picker"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "android-build",
  "block2",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "robius-location"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "android-build",
  "cfg-if",
@@ -1050,7 +1050,7 @@ dependencies = [
 
 [[package]]
 name = "robius-open"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "block2",
  "cfg-if",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "robius-share"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "android-build",
  "cfg-if",
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "robius-web-auth-session"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "block2",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ exclude = [
 
 ## Package details that are shared across multiple crates in the workspace.
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = [
     "Kevin Boos <kevinaboos@gmail.com>",
@@ -77,7 +77,10 @@ objc2-uniform-type-identifiers = { version = "0.3.2", default-features = false, 
 
 
 ## Linux-specific dependencies used in multiple crates in the workspace.
-zbus = ">=5.12.0, <5.13.0"
+
+## Note: default features are off so that each crate can pick the
+## zbus executor backend (async-io / tokio) that it wants.
+zbus = { version = "5.11", default-features = false }
 zbus_polkit = "5.0.0"
 libc = "0.2"
 

--- a/crates/directories/Cargo.toml
+++ b/crates/directories/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "robius-directories"
-version     = "6.0.0"
+version     = "6.0.1"
 authors     = [
     "Simon Ochsenreither <simon@ochsenreither.de>",
     "Kevin Boos <kevinaboos@gmail.com>",
@@ -12,7 +12,7 @@ Supports Linux (XDG spec), Windows (Known Folders), macOS and iOS (Standard Dire
 This crate is a fork of the (now-archived) `directories` crate, with support for Android.
 """
 edition     = "2015"
-rust-version = "1.77.0"
+rust-version = "1.64.0"
 readme      = "README.md"
 license     = "MIT OR Apache-2.0"
 repository  = "https://github.com/project-robius/robius"

--- a/crates/file-picker/Cargo.toml
+++ b/crates/file-picker/Cargo.toml
@@ -72,7 +72,7 @@ objc2-uniform-type-identifiers = { workspace = true, features = [
 
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))'.dependencies]
 rfd = { version = "0.17.2", default-features = false, features = ["xdg-portal"] }
-robius-directories = { path = "../directories" }
+robius-directories = { version = "6.0", path = "../directories" }
 
 
 ## On macOS the native file panels must run on the main thread,

--- a/crates/open/Cargo.toml
+++ b/crates/open/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "robius-open"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
-rust-version = "1.77.0"
+rust-version = "1.72.0"
 authors = [
     "Kevin Boos <kevinaboos@gmail.com>",
     "Klim Tsoutsman <klim@tsoutsman.com>",


### PR DESCRIPTION
Turns out we can depend on `zbus` v5.11.0, and we don't need to be
as strict as we were being.

Also lowered the MSRV and bumped the version for:
* robius-open: now v0.3.1 with MSRV 1.72.0
* robius-directories: now 6.0.1 with MSRV 1.64.0
* robius-authentication: now v0.3.1
 
Closes #18 